### PR TITLE
Finish setting up proper CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,58 +1,88 @@
-name: Haskell CI
-
+name: build
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    [push]
+#   push:
+#     branches: [main, master]
+#   pull_request:
+#     branches: [main, master]
+
+# INFO: The following configuration block ensures that only one build runs per branch,
+# which may be desirable for projects with a costly build process.
+# Remove this block from the CI workflow to let each CI job run to completion.
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  generate-matrix:
-    name: "Generate matrix from cabal"
-    outputs: 
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Extract the tested GHC versions
-        id: set-matrix
-        uses: kleidukos/get-tested@v0.1.7.0
-        with:
-          cabal-file: champ.cabal
-          ubuntu-version: "latest"
-          # macos-version: "latest"
-          # windows-version: "latest"
-          version: 0.1.7.0
-  tests:
-    name: ${{ matrix.ghc }} on ${{ matrix.os }}
-    needs: generate-matrix
+  build:
+    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
-    steps: 
-      - name: Checkout repo
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Set up Haskell
-        id: setup-haskell
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0']
+
+        include:
+          - os: windows-latest
+            ghc-version: '9.8'
+          - os: macos-latest
+            ghc-version: '9.8'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up GHC ${{ matrix.ghc-version }}
         uses: haskell-actions/setup@v2
+        id: setup
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc-version: ${{ matrix.ghc-version }}
+          # Defaults, added for clarity:
           cabal-version: 'latest'
-      - name: Update
-        run: cabal update
-      - name: Freeze
-        run: cabal freeze
-      - name: Cache
-        uses: actions/cache@v4
+          cabal-update: true
+
+      - name: Configure the build
+        run: |
+          cabal configure --enable-tests --enable-benchmarks --disable-documentation
+          cabal build all --dry-run
+        # The last step generates dist-newstyle/cache/plan.json for the cache key.
+
+      - name: Restore cached dependencies
+        uses: actions/cache/restore@v4
+        id: cache
+        env:
+          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
         with:
-          path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
+          restore-keys: ${{ env.key }}-
+
+      - name: Install dependencies
+        # If we had an exact cache hit, the dependencies will be up to date.
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: cabal build all --only-dependencies
+
+      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
+      - name: Save cached dependencies
+        uses: actions/cache/save@v4
+        # If we had an exact cache hit, trying to save the cache would error because of key clash.
+        if: steps.cache.outputs.cache-hit != 'true'
+        with:
+          path: ${{ steps.setup.outputs.cabal-store }}
+          key: ${{ steps.cache.outputs.cache-primary-key }}
+
       - name: Build
-        run: cabal build
-      - name: Test
+        run: cabal build all
+
+      - name: Run tests
         run: cabal test all
+
+      - name: Check cabal file
+        run: cabal check
+
+      - name: Build documentation
+        run:
+          cabal haddock all --disable-documentation
+          # --disable-documentation disables building documentation for dependencies.
+          # The package's own documentation is still built,
+          # yet contains no links to the documentation of the dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,88 +1,10 @@
+on: [push]
 name: build
-on:
-    [push]
-#   push:
-#     branches: [main, master]
-#   pull_request:
-#     branches: [main, master]
-
-# INFO: The following configuration block ensures that only one build runs per branch,
-# which may be desirable for projects with a costly build process.
-# Remove this block from the CI workflow to let each CI job run to completion.
-concurrency:
-  group: build-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  build:
-    name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        ghc-version: ['9.8', '9.6', '9.4', '9.2', '9.0']
-
-        include:
-          - os: windows-latest
-            ghc-version: '9.8'
-          - os: macos-latest
-            ghc-version: '9.8'
-
+  runhaskell:
+    name: Hello World
+    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up GHC ${{ matrix.ghc-version }}
-        uses: haskell-actions/setup@v2
-        id: setup
-        with:
-          ghc-version: ${{ matrix.ghc-version }}
-          # Defaults, added for clarity:
-          cabal-version: 'latest'
-          cabal-update: true
-
-      - name: Configure the build
-        run: |
-          cabal configure --enable-tests --enable-benchmarks --disable-documentation
-          cabal build all --dry-run
-        # The last step generates dist-newstyle/cache/plan.json for the cache key.
-
-      - name: Restore cached dependencies
-        uses: actions/cache/restore@v4
-        id: cache
-        env:
-          key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}-cabal-${{ steps.setup.outputs.cabal-version }}
-        with:
-          path: ${{ steps.setup.outputs.cabal-store }}
-          key: ${{ env.key }}-plan-${{ hashFiles('**/plan.json') }}
-          restore-keys: ${{ env.key }}-
-
-      - name: Install dependencies
-        # If we had an exact cache hit, the dependencies will be up to date.
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: cabal build all --only-dependencies
-
-      # Cache dependencies already here, so that we do not have to rebuild them should the subsequent steps fail.
-      - name: Save cached dependencies
-        uses: actions/cache/save@v4
-        # If we had an exact cache hit, trying to save the cache would error because of key clash.
-        if: steps.cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ steps.setup.outputs.cabal-store }}
-          key: ${{ steps.cache.outputs.cache-primary-key }}
-
-      - name: Build
-        run: cabal build all
-
-      - name: Run tests
-        run: cabal test all
-
-      - name: Check cabal file
-        run: cabal check
-
-      - name: Build documentation
-        run:
-          cabal haddock all --disable-documentation
-          # --disable-documentation disables building documentation for dependencies.
-          # The package's own documentation is still built,
-          # yet contains no links to the documentation of the dependencies.
+      - uses: haskell-actions/setup@v2
+      - run: cabal test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           cabal-file: champ.cabal
           ubuntu-version: "latest"
-          # macos-version: "latest"
+          macos-version: "latest"
           # windows-version: "latest"
           version: 0.1.7.0
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,58 @@
+name: Haskell CI
+
 on: [push]
-name: build
+#  workflow_dispatch:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#     branches:
+#       - main
+
 jobs:
-  runhaskell:
-    name: Hello World
-    runs-on: ubuntu-latest # or macOS-latest, or windows-latest
+  generate-matrix:
+    name: "Generate matrix from cabal"
+    outputs: 
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: haskell-actions/setup@v2
-      - run: cabal test
+      - name: Extract the tested GHC versions
+        id: set-matrix
+        uses: kleidukos/get-tested@v0.1.7.0
+        with:
+          cabal-file: champ.cabal
+          ubuntu-version: "latest"
+          # macos-version: "latest"
+          # windows-version: "latest"
+          version: 0.1.7.0
+  tests:
+    name: ${{ matrix.ghc }} on ${{ matrix.os }}
+    needs: generate-matrix
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJSON(needs.generate-matrix.outputs.matrix) }}
+    steps: 
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Set up Haskell
+        id: setup-haskell
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: 'latest'
+      - name: Update
+        run: cabal update
+      - name: Freeze
+        run: cabal freeze
+      - name: Cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.setup-haskell.outputs.cabal-store }}
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.ghc }}-
+      - name: Build
+        run: cabal build
+      - name: Test
+        run: cabal test all

--- a/cabal.project
+++ b/cabal.project
@@ -5,11 +5,6 @@ write-ghc-environment-files: always
 
 source-repository-package
     type: git
-    location: git@github.com:Qqwy/haskell-primitive-unlifted.git
-    tag: 784fc78815a695db6db69c729a364663e4f0afe2
-
-source-repository-package
-    type: git
     location: git@github.com:Qqwy/haskell-contiguous.git
     tag: d5787ba4d44bf8ebb65de86e6536499f1ada6942
 

--- a/cabal.project
+++ b/cabal.project
@@ -3,10 +3,5 @@ tests: True
 
 write-ghc-environment-files: always
 
-source-repository-package
-    type: git
-    location: git@github.com:Qqwy/haskell-contiguous.git
-    tag: d5787ba4d44bf8ebb65de86e6536499f1ada6942
-
 package *
   ghc-options: -msse4.2 -mavx -mbmi -mbmi2 -optc=-march=native -optc-mtune=native

--- a/cabal.project
+++ b/cabal.project
@@ -5,7 +5,7 @@ write-ghc-environment-files: always
 
 source-repository-package
     type: git
-    location: git@github.com:Qqwy/haskell-contiguous.git
+    location: https://github.com/Qqwy/haskell-contiguous.git
     tag: e6122c3a8b29dc4c4923f60c12c62a8470c1776c
 
 package *

--- a/cabal.project
+++ b/cabal.project
@@ -3,5 +3,10 @@ tests: True
 
 write-ghc-environment-files: always
 
+source-repository-package
+    type: git
+    location: git@github.com:Qqwy/haskell-contiguous.git
+    tag: e6122c3a8b29dc4c4923f60c12c62a8470c1776c
+
 package *
   ghc-options: -msse4.2 -mavx -mbmi -mbmi2 -optc=-march=native -optc-mtune=native

--- a/champ.cabal
+++ b/champ.cabal
@@ -51,7 +51,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC == { 9.6.5, 9.8.4, 9.10.1 }
+tested-with: GHC == { 9.8.4, 9.10.1 }
 
 common warnings
     ghc-options: -Wall -pgmPcpphs -optP--cpp

--- a/champ.cabal
+++ b/champ.cabal
@@ -51,7 +51,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC == { 9.4.8, 9.6.5, 9.8.4, 9.10.1 }
+tested-with: GHC == { 9.6.5, 9.8.4, 9.10.1 }
 
 common warnings
     ghc-options: -Wall -pgmPcpphs -optP--cpp

--- a/champ.cabal
+++ b/champ.cabal
@@ -51,7 +51,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC == { 9.4.8, 9.6.5, 9.8.4, 9.10.1, 9.12.1 }
+tested-with: GHC == { 9.4.8, 9.6.5, 9.8.4, 9.10.1 }
 
 common warnings
     ghc-options: -Wall -pgmPcpphs -optP--cpp


### PR DESCRIPTION
In the end, what fixed is, was using git-based forks in the `cabal.project` over git+https instead of git+ssh (otherwise, you'd need to install a SSH key on the GH action. The 'fetch main repo from github' probably does that as well but gets rid of it before the next action starts. The error on this not working is super cryptic however.)