### PR TITLE
Directly implement `filterWithKey`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -27,6 +27,8 @@ main =
     , foldrBench
     , foldl'SmallBench
     , foldl'Bench
+    , filterWithKeySmallBench
+    , filterWithKeyBench
     , toListSmallBench
     , toListBench
     ]
@@ -226,7 +228,41 @@ toListBench =
           | n <- ([0] <> powersOfTwo)
           ]
 
+filterWithKeySmallBench :: Bench.Benchmark
+filterWithKeySmallBench = do
+  let isEven _ v = even v
+  Bench.bgroup "filterWithKey (small)" $
+     mconcat
+          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBL n),
+              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBB n),
+              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBU n),
+              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUL n),
+              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUB n),
+              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUU n)
+            ]
+          | n <- [0..32]
+          ]
 
+
+filterWithKeyBench :: Bench.Benchmark
+filterWithKeyBench = do
+  let isEven _ v = even v
+  Bench.bgroup "filterWithKey (powers of two)" $
+     mconcat
+          [ [
+              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBL n in inp),
+              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBB n in inp),
+              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBU n in inp),
+              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUL n in inp),
+              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUB n in inp),
+              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUU n in inp)
+            ]
+          | n <- ([0] <> powersOfTwo)
+          ]
 
 -- myinsert :: Int -> Int -> MyLib.MapBL Int Int -> MyLib.MapBL Int Int
 -- {-# NOINLINE myinsert #-}

--- a/champ.cabal
+++ b/champ.cabal
@@ -148,6 +148,7 @@ test-suite test
     build-depends:
         -- Library and datatypes to exercise during tests:
         base,
+        contiguous,
         unordered-containers,
         champ,
         -- Test framework:
@@ -183,7 +184,7 @@ benchmark bench
 
     -- Base language which the package is written in.
     default-language: GHC2021
-    ghc-options:   "-with-rtsopts=-A32m"
+    ghc-options:   "-with-rtsopts=-A32m" -rtsopts
     if impl(ghc >= 8.6)
         ghc-options: -fproc-alignment=64
     main-is:       Bench.hs

--- a/test/suite/ConformanceTest.hs
+++ b/test/suite/ConformanceTest.hs
@@ -7,6 +7,7 @@
 module ConformanceTest where
 
 import Data.HashMap.Strict qualified
+import Control.Monad (forM_)
 import Champ
 import Champ.HashMap qualified
 import Champ.Internal qualified
@@ -26,7 +27,7 @@ tests :: TestLimit
 tests = 5000
 
 test_fromListToList :: [TestTree]
-test_fromListToList = 
+test_fromListToList =
     [ testProperty "toList . fromList conforms (HashMapBL)" $ propFromListToListConforms @HashMapBL
     , testProperty "toList . fromList conforms (HashMapBB)" $ propFromListToListConforms @HashMapBB
     , testProperty "toList . fromList conforms (HashMapBU)" $ propFromListToListConforms @HashMapBU
@@ -36,13 +37,23 @@ test_fromListToList =
     ]
 
 test_lookup :: [TestTree]
-test_lookup = 
+test_lookup =
     [ testProperty "lookup conforms (HashMapBL)" $ propLookupConforms @HashMapBL
     , testProperty "lookup conforms (HashMapBB)" $ propLookupConforms @HashMapBB
     , testProperty "lookup conforms (HashMapBU)" $ propLookupConforms @HashMapBU
     , testProperty "lookup conforms (HashMapUL)" $ propLookupConforms @HashMapUL
     , testProperty "lookup conforms (HashMapUB)" $ propLookupConforms @HashMapUB
     , testProperty "lookup conforms (HashMapUU)" $ propLookupConforms @HashMapUU
+    ]
+
+test_filterWithKey :: [TestTree]
+test_filterWithKey =
+    [ testProperty "filterWithKey conforms (HashMapBL)" $ propFilterWithKeyConforms @HashMapBL
+    , testProperty "filterWithKey conforms (HashMapBB)" $ propFilterWithKeyConforms @HashMapBB
+    , testProperty "filterWithKey conforms (HashMapBU)" $ propFilterWithKeyConforms @HashMapBU
+    , testProperty "filterWithKey conforms (HashMapUL)" $ propFilterWithKeyConforms @HashMapUL
+    , testProperty "filterWithKey conforms (HashMapUB)" $ propFilterWithKeyConforms @HashMapUB
+    , testProperty "filterWithKey conforms (HashMapUU)" $ propFilterWithKeyConforms @HashMapUU
     ]
 
 propFromListToListConforms :: forall champmap keys vals. 
@@ -93,3 +104,50 @@ propLookupConforms = withTests tests $ property $ do
 
     Data.HashMap.Strict.lookup key hs === Champ.HashMap.lookup key cs
     -- Champ.HashMap.lookup key cs === Champ.HashMap.lookup key cs
+
+propFilterWithKeyConforms :: forall champmap keys vals.
+    (champmap ~ HashMap keys vals
+    , MapRepr keys vals Int Int
+    , IsList (champmap Int Int)
+    , Item (champmap Int Int) ~ (Int, Int)
+    , Show (Champ.Internal.Storage.ArrayOf (Strict keys) Int)
+    , Show (Champ.Internal.Storage.ArrayOf vals Int)
+    )
+    => Property
+propFilterWithKeyConforms = withTests tests $ property $ do
+    let n = 1024
+    listInp <- forAll $ Gen.list (Range.linear 0 n) $ do
+        x <- (Gen.int (Range.linear 1 n))
+        b <- Gen.bool
+        pure (x, b)
+
+    let ks = [x | (x, _) <- listInp]
+    let kvs = zip ks ks
+    let fn k _ = Data.HashMap.Strict.lookupDefault (error "impossible") k $
+            Data.HashMap.Strict.fromList listInp
+    annotateShow kvs
+
+    let hs = fromList kvs
+    let cs = fromList kvs :: champmap Int Int
+
+    annotateShow hs
+    annotateShow cs
+    annotate (Champ.Internal.debugShow cs)
+
+    let hsFiltered = Data.HashMap.Strict.filterWithKey fn hs
+    let csFiltered = Champ.HashMap.filterWithKey fn cs
+    annotateShow hsFiltered
+    annotateShow csFiltered
+    annotate (Champ.Internal.debugShow csFiltered)
+
+    -- Check that the hashmaps contain the same things
+    sort (Data.HashMap.Strict.toList hsFiltered) === sort (Champ.HashMap.toList csFiltered)
+    -- Check that champ contains the correct structure.
+    forM_ ks $ \k -> do
+        Data.HashMap.Strict.lookup k hsFiltered === (Champ.HashMap.lookup k csFiltered)
+
+    -- Check that we didn't mutate anything the unfiltered pointed to.
+    sort (Data.HashMap.Strict.toList hs) === sort (Champ.HashMap.toList cs)
+    -- Check that champ contains the correct structure.
+    forM_ ks $ \k -> do
+        Data.HashMap.Strict.lookup k hs === (Champ.HashMap.lookup k cs)


### PR DESCRIPTION
Implements `filterWithKey` (and `filter`) through direct traversals. Did some funny tricks which I might turn into a blog post. I suspect there's still some potential juice left in the inlining of children subnodes when filtering by removing the `insertAt`s, but this is already faster then unordered-containers for large enough inputs.

<details><summary>Benchmark results</summary>

```
All
  filterWithKey (small)
    Data.HashMap.Lazy.0:      OK
      8.36 ns ± 478 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.0:    OK
      8.36 ns ± 400 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.0:              OK
      10.7 ns ± 668 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.0:              OK
      10.9 ns ± 1.1 ns,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.0:              OK
      10.9 ns ± 1.1 ns,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.0:              OK
      10.8 ns ± 608 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.0:              OK
      11.4 ns ± 852 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.0:              OK
      9.33 ns ± 610 ps,  31 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.1:      OK
      15.1 ns ± 1.5 ns,  31 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.1:    OK
      14.3 ns ± 1.0 ns,  31 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.1:              OK
      13.8 ns ± 1.3 ns,  79 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.1:              OK
      14.5 ns ± 202 ps,  79 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.1:              OK
      14.1 ns ± 1.2 ns,  79 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.1:              OK
      14.3 ns ± 798 ps,  79 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.1:              OK
      14.1 ns ±  54 ps,  79 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.1:              OK
      12.6 ns ± 628 ps,  79 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.2:      OK
      33.1 ns ± 2.7 ns,  63 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.2:    OK
      33.6 ns ± 3.0 ns,  63 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.2:              OK
      66.9 ns ± 3.0 ns, 254 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.2:              OK
      53.5 ns ± 1.8 ns, 215 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.2:              OK
      51.4 ns ± 1.9 ns, 229 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.2:              OK
      60.7 ns ± 3.2 ns, 264 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.2:              OK
      50.7 ns ± 2.4 ns, 227 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.2:              OK
      47.9 ns ± 3.2 ns, 234 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.3:      OK
      52.1 ns ± 2.3 ns,  95 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.3:    OK
      51.6 ns ± 4.7 ns,  95 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.3:              OK
      97.8 ns ± 9.1 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.3:              OK
      85.3 ns ± 3.1 ns, 286 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.3:              OK
      83.2 ns ± 5.3 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.3:              OK
      91.7 ns ± 7.4 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.3:              OK
      79.8 ns ± 3.1 ns, 286 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.3:              OK
      73.4 ns ± 3.1 ns, 235 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.4:      OK
      57.5 ns ± 3.7 ns,  95 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.4:    OK
      57.2 ns ± 4.3 ns,  95 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.4:              OK
      101  ns ± 8.5 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.4:              OK
      91.6 ns ± 6.7 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.4:              OK
      85.3 ns ± 5.5 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.4:              OK
      96.5 ns ± 4.2 ns, 286 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.4:              OK
      82.1 ns ± 7.9 ns, 280 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.4:              OK
      74.3 ns ± 2.7 ns, 235 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.5:      OK
      71.6 ns ± 6.5 ns,  89 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.5:    OK
      70.5 ns ± 6.9 ns,  89 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.5:              OK
      130  ns ±  12 ns, 305 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.5:              OK
      113  ns ± 9.7 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.5:              OK
      105  ns ± 6.8 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.5:              OK
      123  ns ±  12 ns, 305 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.5:              OK
      104  ns ± 8.6 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.5:              OK
      89.5 ns ± 7.0 ns, 254 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.6:      OK
      76.6 ns ± 2.8 ns, 108 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.6:    OK
      77.2 ns ± 7.7 ns,  89 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.6:              OK
      135  ns ±  12 ns, 305 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.6:              OK
      113  ns ± 8.1 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.6:              OK
      106  ns ± 3.4 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.6:              OK
      125  ns ±  12 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.6:              OK
      104  ns ± 3.1 ns, 318 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.6:              OK
      91.8 ns ± 3.7 ns, 267 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.7:      OK
      90.7 ns ± 7.6 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.7:    OK
      89.5 ns ± 6.6 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.7:              OK
      155  ns ±  14 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.7:              OK
      133  ns ± 8.6 ns, 344 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.7:              OK
      120  ns ± 8.0 ns, 344 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.7:              OK
      146  ns ±  14 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.7:              OK
      126  ns ±  12 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.7:              OK
      109  ns ± 5.1 ns, 279 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.8:      OK
      96.6 ns ± 7.1 ns, 127 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.8:    OK
      95.8 ns ± 8.4 ns, 127 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.8:              OK
      159  ns ±  14 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.8:              OK
      134  ns ± 7.0 ns, 344 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.8:              OK
      123  ns ±  10 ns, 344 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.8:              OK
      152  ns ±  15 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.8:              OK
      125  ns ± 8.4 ns, 344 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.8:              OK
      109  ns ± 7.0 ns, 279 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.9:      OK
      110  ns ± 6.7 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.9:    OK
      109  ns ± 5.2 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.9:              OK
      188  ns ± 8.1 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.9:              OK
      171  ns ±  13 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.9:              OK
      150  ns ±  10 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.9:              OK
      181  ns ± 6.2 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.9:              OK
      151  ns ± 6.5 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.9:              OK
      131  ns ±  10 ns, 305 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.10:     OK
      119  ns ±  11 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.10:   OK
      116  ns ± 7.9 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.10:             OK
      211  ns ±  21 ns, 356 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.10:             OK
      189  ns ±  12 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.10:             OK
      178  ns ±  17 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.10:             OK
      198  ns ±  18 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.10:             OK
      153  ns ± 5.8 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.10:             OK
      132  ns ±  11 ns, 305 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.11:     OK
      135  ns ±  11 ns, 158 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.11:   OK
      139  ns ±  12 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.11:             OK
      234  ns ±  13 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.11:             OK
      206  ns ±  17 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.11:             OK
      178  ns ±  11 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.11:             OK
      207  ns ±  18 ns, 407 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.11:             OK
      178  ns ±  15 ns, 382 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUU.11:             OK
      154  ns ±  13 ns, 306 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.12:     OK
      149  ns ±  15 ns, 126 B  allocated,   0 B  copied,  36 MB peak memory
    Data.HashMap.Strict.12:   OK
      133  ns ± 4.8 ns, 157 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.12:             OK
      262  ns ±  25 ns, 414 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBB.12:             OK
      215  ns ±  12 ns, 414 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapBU.12:             OK
      177  ns ±  13 ns, 407 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUL.12:             OK
      240  ns ± 2.6 ns, 414 B  allocated,   0 B  copied,  36 MB peak memory
    HashMapUB.12:             OK
      178  ns ±  15 ns, 407 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.12:             OK
      149  ns ± 6.6 ns, 344 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.13:     OK
      149  ns ± 9.3 ns, 152 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.13:   OK
      151  ns ± 7.5 ns, 152 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.13:             OK
      284  ns ±  12 ns, 431 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.13:             OK
      232  ns ±  18 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.13:             OK
      194  ns ±  12 ns, 431 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.13:             OK
      252  ns ±  21 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.13:             OK
      221  ns ±  16 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.13:             OK
      195  ns ±  11 ns, 380 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.14:     OK
      164  ns ±  12 ns, 127 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.14:   OK
      191  ns ±  13 ns, 127 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.14:             OK
      287  ns ±  21 ns, 355 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.14:             OK
      249  ns ±  22 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.14:             OK
      193  ns ±  10 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.14:             OK
      245  ns ±  11 ns, 431 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.14:             OK
      252  ns ±  22 ns, 443 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.14:             OK
      177  ns ±  10 ns, 380 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.15:     OK
      189  ns ±  15 ns, 178 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.15:   OK
      187  ns ±  16 ns, 178 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.15:             OK
      282  ns ±  13 ns, 471 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.15:             OK
      241  ns ±  16 ns, 433 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.15:             OK
      209  ns ±  11 ns, 433 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.15:             OK
      264  ns ±  21 ns, 356 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.15:             OK
      220  ns ±  14 ns, 433 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.15:             OK
      188  ns ±  10 ns, 381 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.16:     OK
      189  ns ±  12 ns, 176 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.16:   OK
      188  ns ±  15 ns, 176 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.16:             OK
      284  ns ±  24 ns, 356 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.16:             OK
      242  ns ±  15 ns, 433 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.16:             OK
      211  ns ±  11 ns, 433 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.16:             OK
      269  ns ±  22 ns, 356 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.16:             OK
      221  ns ±  20 ns, 356 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.16:             OK
      189  ns ±  13 ns, 381 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.17:     OK
      202  ns ±  13 ns, 174 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.17:   OK
      201  ns ±  15 ns, 174 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.17:             OK
      310  ns ±  24 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.17:             OK
      267  ns ±  12 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.17:             OK
      233  ns ±  13 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.17:             OK
      306  ns ±  28 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.17:             OK
      253  ns ±  22 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.17:             OK
      215  ns ±  17 ns, 431 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.18:     OK
      216  ns ±  11 ns, 188 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.18:   OK
      220  ns ±  20 ns, 188 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.18:             OK
      367  ns ±  15 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.18:             OK
      296  ns ±  23 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.18:             OK
      234  ns ±  11 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.18:             OK
      319  ns ±  27 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.18:             OK
      262  ns ±  17 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.18:             OK
      248  ns ±  19 ns, 444 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.19:     OK
      226  ns ± 1.4 ns, 220 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.19:   OK
      218  ns ±  16 ns, 214 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.19:             OK
      339  ns ±  24 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.19:             OK
      310  ns ±  21 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.19:             OK
      248  ns ±  19 ns, 532 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.19:             OK
      314  ns ±  13 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.19:             OK
      263  ns ±  17 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.19:             OK
      228  ns ±  21 ns, 353 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.20:     OK
      228  ns ±  22 ns, 101 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.20:   OK
      223  ns ±  18 ns, 177 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.20:             OK
      338  ns ±  18 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.20:             OK
      298  ns ±  23 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.20:             OK
      248  ns ±  19 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.20:             OK
      320  ns ±  11 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.20:             OK
      262  ns ±  25 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.20:             OK
      226  ns ±  17 ns, 429 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.21:     OK
      239  ns ±  20 ns, 101 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.21:   OK
      235  ns ±  17 ns, 177 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.21:             OK
      368  ns ±  27 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.21:             OK
      324  ns ±  26 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.21:             OK
      273  ns ±  21 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.21:             OK
      344  ns ±  34 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.21:             OK
      284  ns ±  14 ns, 559 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.21:             OK
      249  ns ±  22 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.22:     OK
      247  ns ±  22 ns, 100 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.22:   OK
      246  ns ±  21 ns, 100 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.22:             OK
      370  ns ±  33 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.22:             OK
      315  ns ±  12 ns, 559 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.22:             OK
      271  ns ±  14 ns, 559 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.22:             OK
      354  ns ±  29 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.22:             OK
      288  ns ±  22 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.22:             OK
      246  ns ±  16 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.23:     OK
      254  ns ±  10 ns, 250 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.23:   OK
      256  ns ±  13 ns, 250 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.23:             OK
      394  ns ±  26 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.23:             OK
      344  ns ±  29 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.23:             OK
      288  ns ±  25 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.23:             OK
      379  ns ±  32 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.23:             OK
      305  ns ±  21 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.23:             OK
      266  ns ±  26 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.24:     OK
      259  ns ±  16 ns, 248 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.24:   OK
      263  ns ±  10 ns, 248 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.24:             OK
      400  ns ±  29 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.24:             OK
      345  ns ±  29 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.24:             OK
      287  ns ±  15 ns, 558 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.24:             OK
      376  ns ±  14 ns, 558 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.24:             OK
      305  ns ±  29 ns, 508 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.24:             OK
      263  ns ±  17 ns, 507 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.25:     OK
      276  ns ±  13 ns, 245 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.25:   OK
      278  ns ±  14 ns, 245 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.25:             OK
      499  ns ±  35 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.25:             OK
      404  ns ±  27 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.25:             OK
      326  ns ±  24 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.25:             OK
      414  ns ±  26 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.25:             OK
      340  ns ±  27 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.25:             OK
      287  ns ±  24 ns, 509 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.26:     OK
      289  ns ±  22 ns, 252 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Strict.26:   OK
      284  ns ±  25 ns, 252 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBL.26:             OK
      460  ns ±  14 ns, 637 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBB.26:             OK
      420  ns ±  33 ns, 637 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapBU.26:             OK
      345  ns ±  31 ns, 637 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUL.26:             OK
      424  ns ±  38 ns, 611 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUB.26:             OK
      361  ns ±  31 ns, 637 B  allocated,   0 B  copied,  37 MB peak memory
    HashMapUU.26:             OK
      298  ns ±  25 ns, 509 B  allocated,   0 B  copied,  37 MB peak memory
    Data.HashMap.Lazy.27:     OK
      306  ns ±  26 ns, 247 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.27:   OK
      292  ns ± 4.0 ns, 284 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.27:             OK
      481  ns ±  22 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.27:             OK
      413  ns ±  22 ns, 638 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.27:             OK
      338  ns ±  12 ns, 638 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.27:             OK
      449  ns ±  21 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.27:             OK
      354  ns ±  31 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.27:             OK
      314  ns ±  23 ns, 509 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.28:     OK
      299  ns ±  17 ns, 254 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.28:   OK
      301  ns ±  29 ns, 254 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.28:             OK
      484  ns ±  30 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.28:             OK
      418  ns ±  30 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.28:             OK
      338  ns ±  11 ns, 638 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.28:             OK
      451  ns ±  24 ns, 612 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.28:             OK
      355  ns ±  11 ns, 638 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.28:             OK
      302  ns ±  20 ns, 560 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.29:     OK
      313  ns ±  25 ns, 248 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.29:   OK
      314  ns ±  14 ns, 248 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.29:             OK
      511  ns ±  47 ns, 509 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.29:             OK
      441  ns ±  32 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.29:             OK
      359  ns ±  23 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.29:             OK
      469  ns ±  33 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.29:             OK
      378  ns ±  29 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.29:             OK
      322  ns ±  16 ns, 637 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.30:     OK
      319  ns ±  21 ns, 255 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.30:   OK
      325  ns ±  26 ns, 255 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.30:             OK
      509  ns ±  31 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.30:             OK
      447  ns ±  24 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.30:             OK
      357  ns ±  31 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.30:             OK
      471  ns ±  28 ns, 611 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.30:             OK
      373  ns ±  18 ns, 688 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.30:             OK
      326  ns ±  14 ns, 637 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.31:     OK
      338  ns ±  21 ns, 248 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.31:   OK
      341  ns ±  26 ns, 298 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.31:             OK
      535  ns ±  28 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.31:             OK
      463  ns ±  25 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.31:             OK
      389  ns ±  32 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.31:             OK
      507  ns ±  46 ns, 507 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.31:             OK
      400  ns ±  21 ns, 684 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.31:             OK
      368  ns ±  36 ns, 607 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.32:     OK
      338  ns ±  26 ns, 254 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.32:   OK
      337  ns ±  30 ns, 254 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.32:             OK
      545  ns ±  42 ns, 507 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.32:             OK
      464  ns ±  36 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.32:             OK
      390  ns ±  22 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.32:             OK
      507  ns ±  30 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.32:             OK
      406  ns ±  32 ns, 608 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.32:             OK
      374  ns ±  31 ns, 607 B  allocated,   0 B  copied,  38 MB peak memory
  filterWithKey (powers of two)
    Data.HashMap.Lazy.0:      OK
      9.13 ns ± 442 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Strict.0:    OK
      8.40 ns ± 372 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBL.0:              OK
      10.6 ns ± 974 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBB.0:              OK
      10.8 ns ± 532 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapBU.0:              OK
      10.9 ns ± 888 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUL.0:              OK
      10.6 ns ± 324 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUB.0:              OK
      10.8 ns ± 484 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    HashMapUU.0:              OK
      9.22 ns ± 466 ps,  31 B  allocated,   0 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.1:      OK
      14.3 ns ± 694 ps,  31 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.1:    OK
      13.6 ns ± 1.3 ns,  31 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.1:              OK
      13.6 ns ± 540 ps,  79 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.1:              OK
      13.6 ns ± 986 ps,  79 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.1:              OK
      13.5 ns ± 1.0 ns,  79 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.1:              OK
      13.9 ns ± 986 ps,  79 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.1:              OK
      13.8 ns ± 1.3 ns,  79 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.1:              OK
      12.9 ns ± 1.0 ns,  79 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.2:      OK
      32.9 ns ± 1.9 ns,  63 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.2:    OK
      32.7 ns ± 1.8 ns,  63 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.2:              OK
      62.4 ns ± 5.0 ns, 253 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.2:              OK
      53.7 ns ± 3.1 ns, 203 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.2:              OK
      52.3 ns ± 4.6 ns, 221 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.2:              OK
      62.8 ns ± 6.2 ns, 252 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.2:              OK
      51.2 ns ± 4.1 ns, 221 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.2:              OK
      47.9 ns ± 3.9 ns, 234 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.4:      OK
      59.2 ns ± 5.6 ns,  89 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.4:    OK
      57.9 ns ± 2.7 ns,  95 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.4:              OK
      102  ns ± 7.8 ns, 280 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.4:              OK
      88.7 ns ± 6.6 ns, 280 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.4:              OK
      84.6 ns ± 6.5 ns, 280 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.4:              OK
      95.6 ns ± 8.0 ns, 280 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.4:              OK
      82.9 ns ± 6.7 ns, 280 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.4:              OK
      74.3 ns ± 6.4 ns, 216 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.8:      OK
      95.5 ns ± 5.6 ns, 127 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.8:    OK
      94.9 ns ± 8.6 ns, 127 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.8:              OK
      159  ns ± 6.0 ns, 344 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.8:              OK
      134  ns ± 7.3 ns, 344 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.8:              OK
      125  ns ± 7.9 ns, 344 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.8:              OK
      148  ns ±  10 ns, 344 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.8:              OK
      126  ns ± 5.3 ns, 344 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.8:              OK
      108  ns ± 9.6 ns, 279 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.16:     OK
      186  ns ±  14 ns, 176 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.16:   OK
      185  ns ±  15 ns, 176 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.16:             OK
      284  ns ±  23 ns, 356 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.16:             OK
      243  ns ±  14 ns, 433 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.16:             OK
      210  ns ±  20 ns, 433 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.16:             OK
      268  ns ±  25 ns, 356 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.16:             OK
      222  ns ±  22 ns, 356 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.16:             OK
      187  ns ±  15 ns, 381 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.32:     OK
      338  ns ±  24 ns, 254 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.32:   OK
      333  ns ±  20 ns, 305 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.32:             OK
      543  ns ±  21 ns, 608 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.32:             OK
      465  ns ±  38 ns, 608 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.32:             OK
      391  ns ±  25 ns, 608 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.32:             OK
      509  ns ±  28 ns, 608 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.32:             OK
      407  ns ±  25 ns, 608 B  allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.32:             OK
      374  ns ±  22 ns, 607 B  allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.64:     OK
      1.19 μs ±  86 ns, 1.3 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.64:   OK
      1.18 μs ± 100 ns, 1.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.64:             OK
      1.50 μs ± 109 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.64:             OK
      1.34 μs ±  55 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.64:             OK
      1.32 μs ±  90 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.64:             OK
      1.50 μs ± 116 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.64:             OK
      1.28 μs ±  43 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.64:             OK
      1.19 μs ±  72 ns, 4.9 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.128:    OK
      1.80 μs ± 107 ns, 2.0 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.128:  OK
      1.79 μs ± 176 ns, 2.0 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.128:            OK
      1.93 μs ± 158 ns, 5.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.128:            OK
      1.67 μs ±  86 ns, 5.4 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.128:            OK
      1.60 μs ±  82 ns, 5.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.128:            OK
      1.95 μs ±  94 ns, 5.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.128:            OK
      1.59 μs ±  52 ns, 5.4 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.128:            OK
      1.52 μs ± 116 ns, 5.4 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.256:    OK
      3.13 μs ± 287 ns, 2.8 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.256:  OK
      3.12 μs ± 228 ns, 2.8 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.256:            OK
      2.83 μs ± 219 ns, 5.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBB.256:            OK
      2.32 μs ± 228 ns, 5.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBU.256:            OK
      2.05 μs ±  86 ns, 6.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUL.256:            OK
      2.82 μs ± 198 ns, 5.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUB.256:            OK
      2.11 μs ± 117 ns, 6.3 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapUU.256:            OK
      2.05 μs ± 115 ns, 6.3 KB allocated,   1 B  copied,  39 MB peak memory
    Data.HashMap.Lazy.512:    OK
      5.83 μs ± 369 ns, 3.9 KB allocated,   0 B  copied,  39 MB peak memory
    Data.HashMap.Strict.512:  OK
      5.81 μs ± 339 ns, 3.9 KB allocated,   0 B  copied,  39 MB peak memory
    HashMapBL.512:            OK
      4.69 μs ± 403 ns, 7.9 KB allocated,   1 B  copied,  39 MB peak memory
    HashMapBB.512:            OK
      3.52 μs ± 206 ns, 7.9 KB allocated,   1 B  copied,  39 MB peak memory
    HashMapBU.512:            OK
      3.13 μs ± 239 ns, 7.9 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUL.512:            OK
      4.66 μs ± 410 ns, 7.9 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUB.512:            OK
      3.33 μs ± 184 ns, 7.9 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUU.512:            OK
      3.09 μs ± 219 ns, 7.9 KB allocated,   1 B  copied,  40 MB peak memory
    Data.HashMap.Lazy.1024:   OK
      10.5 μs ± 336 ns, 8.0 KB allocated,   1 B  copied,  40 MB peak memory
    Data.HashMap.Strict.1024: OK
      10.6 μs ± 737 ns, 8.0 KB allocated,   2 B  copied,  40 MB peak memory
    HashMapBL.1024:           OK
      8.49 μs ± 725 ns,  11 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapBB.1024:           OK
      6.04 μs ± 447 ns,  12 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapBU.1024:           OK
      5.03 μs ± 243 ns,  12 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUL.1024:           OK
      8.39 μs ± 711 ns,  11 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUB.1024:           OK
      5.53 μs ± 456 ns,  12 KB allocated,   1 B  copied,  40 MB peak memory
    HashMapUU.1024:           OK
      5.25 μs ± 409 ns,  12 KB allocated,   1 B  copied,  40 MB peak memory
    Data.HashMap.Lazy.2048:   OK
      38.2 μs ± 3.4 μs,  43 KB allocated,  37 B  copied,  40 MB peak memory
    Data.HashMap.Strict.2048: OK
      37.5 μs ± 1.9 μs,  46 KB allocated,  38 B  copied,  41 MB peak memory
    HashMapBL.2048:           OK
      46.8 μs ± 3.2 μs, 140 KB allocated,  75 B  copied,  41 MB peak memory
    HashMapBB.2048:           OK
      43.7 μs ± 3.8 μs, 140 KB allocated,  71 B  copied,  41 MB peak memory
    HashMapBU.2048:           OK
      42.2 μs ± 2.9 μs, 140 KB allocated,  75 B  copied,  42 MB peak memory
    HashMapUL.2048:           OK
      47.4 μs ± 3.0 μs, 140 KB allocated,  86 B  copied,  42 MB peak memory
    HashMapUB.2048:           OK
      42.3 μs ± 2.7 μs, 140 KB allocated,  70 B  copied,  42 MB peak memory
    HashMapUU.2048:           OK
      38.6 μs ± 1.7 μs, 149 KB allocated,  74 B  copied,  42 MB peak memory
    Data.HashMap.Lazy.4096:   OK
      57.6 μs ± 3.9 μs,  64 KB allocated,  60 B  copied,  43 MB peak memory
    Data.HashMap.Strict.4096: OK
      58.1 μs ± 2.9 μs,  64 KB allocated,  60 B  copied,  43 MB peak memory
    HashMapBL.4096:           OK
      61.7 μs ± 4.2 μs, 158 KB allocated,  84 B  copied,  44 MB peak memory
    HashMapBB.4096:           OK
      54.7 μs ± 3.0 μs, 158 KB allocated,  79 B  copied,  44 MB peak memory
    HashMapBU.4096:           OK
      50.5 μs ± 3.6 μs, 158 KB allocated,  79 B  copied,  45 MB peak memory
    HashMapUL.4096:           OK
      63.5 μs ± 3.3 μs, 158 KB allocated,  89 B  copied,  45 MB peak memory
    HashMapUB.4096:           OK
      51.6 μs ± 1.7 μs, 165 KB allocated,  93 B  copied,  46 MB peak memory
    HashMapUU.4096:           OK
      47.1 μs ± 2.0 μs, 165 KB allocated,  84 B  copied,  46 MB peak memory
    Data.HashMap.Lazy.8192:   OK
      100  μs ± 7.6 μs,  88 KB allocated, 112 B  copied,  47 MB peak memory
    Data.HashMap.Strict.8192: OK
      100  μs ± 7.4 μs,  88 KB allocated, 108 B  copied,  48 MB peak memory
    HashMapBL.8192:           OK
      94.3 μs ± 5.7 μs, 190 KB allocated, 114 B  copied,  48 MB peak memory
    HashMapBB.8192:           OK
      74.5 μs ± 4.1 μs, 190 KB allocated,  95 B  copied,  49 MB peak memory
    HashMapBU.8192:           OK
      65.1 μs ± 4.0 μs, 190 KB allocated,  99 B  copied,  50 MB peak memory
    HashMapUL.8192:           OK
      94.6 μs ± 6.5 μs, 190 KB allocated, 114 B  copied,  50 MB peak memory
    HashMapUB.8192:           OK
      71.3 μs ± 2.9 μs, 190 KB allocated,  99 B  copied,  51 MB peak memory
    HashMapUU.8192:           OK
      64.1 μs ± 4.4 μs, 190 KB allocated, 102 B  copied,  51 MB peak memory
```

</details>