### PR TITLE
Directly implement `mapMaybeWithKey`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,3 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
-

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -17,27 +17,27 @@ import Data.String (IsString(..))
 main :: IO ()
 main =
   Bench.defaultMain
-    [ insertSmallBench
-    , insertBench
-    , lookupSmallBench
-    , lookupBench
-    , lookupByteArraySmallBench
-    , lookupByteArrayBench
-    , foldrSmallBench
-    , foldrBench
-    , foldl'SmallBench
-    , foldl'Bench
-    , filterWithKeyBench [0..32]
-    , filterWithKeyBench (0 : powersOfTwo 13)
-    , mapMaybeWithKeyBench [0..32]
-    , mapMaybeWithKeyBench (0 : powersOfTwo 13)
-    , toListSmallBench
-    , toListBench
+    [ insertBench "small" [1..32]
+    , insertBench "(powers of two)" (powersOfTwo 10)
+    , lookupBench "small" [1..32]
+    , lookupBench "(powers of two)" (powersOfTwo 10)
+    , lookupByteArrayBench "small" [1..32]
+    , lookupByteArrayBench "(powers of two)" (powersOfTwo 10)
+    , foldrBench "small" [1..32]
+    , foldrBench "(powers of two)" (powersOfTwo 10)
+    , foldl'Bench "small" [1..32]
+    , foldl'Bench "(powers of two)" (powersOfTwo 10)
+    , filterWithKeyBench "small" [0..32]
+    , filterWithKeyBench "(powers of two)" (powersOfTwo 13)
+    , mapMaybeWithKeyBench "small" [0..32]
+    , mapMaybeWithKeyBench "(powers of two)" (powersOfTwo 13)
+    , toListBench "small" [1..32]
+    , toListBench "(powers of two)" (powersOfTwo 10)
     ]
 
-insertSmallBench :: Bench.Benchmark
-insertSmallBench =
-  Bench.bgroup "insert (small)" $
+insertBench :: String -> [Int] -> Bench.Benchmark
+insertBench s ns =
+  Bench.bgroup ("insert " <> s) $
     mconcat
       [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.insert n n) (buildN n),
           Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.insert n n) (buildN n),
@@ -48,28 +48,12 @@ insertSmallBench =
           Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUB n),
           Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUU n)
         ]
-      | n <- ([0..32])
+      | n <- ns
       ]
 
-insertBench :: Bench.Benchmark
-insertBench =
-  Bench.bgroup "insert (powers of two)" $
-    mconcat
-      [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.insert n n) (buildN n),
-          Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.insert n n) (buildN n),
-          Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapBL n),
-          Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapBB n),
-          Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapBU n),
-          Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUL n),
-          Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUB n),
-          Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUU n)
-        ]
-      | n <- ([0] <> powersOfTwo 10)
-      ]
-
-lookupSmallBench :: Bench.Benchmark
-lookupSmallBench =
-  Bench.bgroup "Lookup (small)" $
+lookupBench :: String -> [Int] -> Bench.Benchmark
+lookupBench s ns =
+  Bench.bgroup ("Lookup " <> s) $
     mconcat
       [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.lookup (n)) (buildN n),
           Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.lookup (n)) (buildN n),
@@ -80,28 +64,12 @@ lookupSmallBench =
           Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUB n),
           Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUU n)
         ]
-      | n <- [0..32]
+      | n <- ns
       ]
 
-lookupBench :: Bench.Benchmark
-lookupBench =
-  Bench.bgroup "Lookup (powers of two)" $
-    mconcat
-      [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.lookup (n)) (buildN n),
-          Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.lookup (n)) (buildN n),
-          Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapBL n),
-          Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapBB n),
-          Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapBU n),
-          Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUL n),
-          Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUB n),
-          Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUU n)
-        ]
-      | n <- powersOfTwo 10
-      ]
-
-lookupByteArraySmallBench :: Bench.Benchmark
-lookupByteArraySmallBench =
-  Bench.bgroup "Lookup ShortText (small)" $
+lookupByteArrayBench :: String -> [Int] -> Bench.Benchmark
+lookupByteArrayBench s ns =
+  Bench.bgroup ("Lookup ShortText " <> s) $
     mconcat
       [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.lookup (fromString (show n))) (buildBAN @HashMap n),
           Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.lookup (fromString (show n))) (buildBAN @HashMap n),
@@ -112,28 +80,12 @@ lookupByteArraySmallBench =
           Bench.bench ("HashMapUlB." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlB n),
           Bench.bench ("HashMapUlU." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlU n)
         ]
-      | n <- [0..32]
+      | n <- ns
       ]
 
-lookupByteArrayBench :: Bench.Benchmark
-lookupByteArrayBench =
-  Bench.bgroup "Lookup ShortText (powers of two)" $
-    mconcat
-      [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.lookup (fromString (show n))) (buildBAN @HashMap n),
-          Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.lookup (fromString (show n))) (buildBAN @HashMap n),
-          Bench.bench ("HashMapBL." <> show n) $ Bench.nf  (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapBL n),
-          Bench.bench ("HashMapBB." <> show n) $ Bench.nf  (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapBB n),
-          Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapBU n),
-          Bench.bench ("HashMapUlL." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlL n),
-          Bench.bench ("HashMapUlB." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlB n),
-          Bench.bench ("HashMapUlU." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlU n)
-        ]
-      | n <- powersOfTwo 10
-      ]
-
-foldrSmallBench :: Bench.Benchmark
-foldrSmallBench =
-  Bench.bgroup "Foldr (+) 0 (small)" $
+foldrBench :: String -> [Int] -> Bench.Benchmark
+foldrBench s ns =
+  Bench.bgroup ("Foldr (+) 0 " <> s) $
     mconcat
           [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.foldr (+) 0) (buildN @HashMap n),
               Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.foldr (+) 0) (buildN @HashMap n),
@@ -144,29 +96,12 @@ foldrSmallBench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUU n)
             ]
-          | n <- [0..32]
+          | n <- ns
           ]
 
-
-foldrBench :: Bench.Benchmark
-foldrBench =
-  Bench.bgroup "Foldr (+) 0 (powers of two)" $
-    mconcat
-          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.foldr (+) 0) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.foldr (+) 0) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapBL n),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapBB n),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapBU n),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUL n),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUB n),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUU n)
-            ]
-          | n <- ([0] <> powersOfTwo 10)
-          ]
-
-foldl'SmallBench :: Bench.Benchmark
-foldl'SmallBench =
-  Bench.bgroup "foldl' (+) 0 (small)" $
+foldl'Bench :: String -> [Int] -> Bench.Benchmark
+foldl'Bench s ns =
+  Bench.bgroup ("foldl' (+) 0 " <> s) $
     mconcat
           [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.foldl' (+) 0) (buildN @HashMap n),
               Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.foldl' (+) 0) (buildN @HashMap n),
@@ -177,29 +112,12 @@ foldl'SmallBench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUU n)
             ]
-          | n <- [0..32]
+          | n <- ns
           ]
 
-
-foldl'Bench :: Bench.Benchmark
-foldl'Bench =
-  Bench.bgroup "foldl' (+) 0 (powers of two)" $
-    mconcat
-          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.foldl' (+) 0) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.foldl' (+) 0) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapBL n),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapBB n),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapBU n),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUL n),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUB n),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUU n)
-            ]
-          | n <- ([0] <> powersOfTwo 10)
-          ]
-
-toListSmallBench :: Bench.Benchmark
-toListSmallBench =
-  Bench.bgroup "toList (small)" $
+toListBench :: String -> [Int] -> Bench.Benchmark
+toListBench s ns =
+  Bench.bgroup ("toList " <> s) $
      mconcat
           [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.toList) (buildN @HashMap n),
               Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.toList) (buildN @HashMap n),
@@ -210,66 +128,53 @@ toListSmallBench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUU n)
             ]
-          | n <- [0..32]
+          | n <- ns
           ]
 
-
-toListBench :: Bench.Benchmark
-toListBench =
-  Bench.bgroup "toList (powers of two)" $
-     mconcat
-          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.toList) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.toList) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapBL n),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapBB n),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapBU n),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUL n),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUB n),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUU n)
-            ]
-          | n <- ([0] <> powersOfTwo 10)
-          ]
-
-
-filterWithKeyBench :: [Int] -> Bench.Benchmark
-filterWithKeyBench ns = do
+filterWithKeyBench :: String -> [Int] -> Bench.Benchmark
+filterWithKeyBench s ns = do
   let isEven _ v = even v
-  Bench.bgroup "filterWithKey (powers of two)" $
-     mconcat
-          [ [
-              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBL n),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBB n),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBU n),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUL n),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUB n),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUU n)
-            ]
-          | n <- ns
-          ]
+  Bench.bgroup ("filterWithKey " <> s) $
+    mconcat
+      [ benchmarksTranformOn
+          (Data.HashMap.Lazy.filterWithKey isEven)
+          (Data.HashMap.Strict.filterWithKey isEven)
+          (Champ.HashMap.filterWithKey isEven)
+          n
+      | n <- ns
+      ]
 
+mapMaybeWithKeyBench :: String -> [Int] -> Bench.Benchmark
+mapMaybeWithKeyBench s ns = do
+  let isEven _ v = if even v then Just v else Nothing
+  Bench.bgroup ("mapMaybeWithKey " <> s) $
+    mconcat
+      [ benchmarksTranformOn
+          (Data.HashMap.Lazy.mapMaybeWithKey isEven)
+          (Data.HashMap.Strict.mapMaybeWithKey isEven)
+          (Champ.HashMap.mapMaybeWithKey isEven)
+          n
+      | n <- ns
+      ]
 
-mapMaybeWithKeyBench :: [Int] -> Bench.Benchmark
-mapMaybeWithKeyBench ns = do
-  let isEven _ v =
-        if even v
-          then Just v
-          else Nothing
-  Bench.bgroup "mapMaybeWithKey (powers of two)" $
-     mconcat
-          [ [
-              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.mapMaybeWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.mapMaybeWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBL n),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBB n),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBU n),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUL n),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUB n),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUU n)
-            ]
-          | n <- ns
-          ]
+benchmarksTranformOn ::
+  (HashMap Int Int -> HashMap Int Int) ->
+  (HashMap Int Int -> HashMap Int Int) ->
+  ( forall keys vals.
+    (MapRepr keys vals Int Int) => Champ.HashMap.HashMap keys vals Int Int -> Champ.HashMap.HashMap keys vals Int Int
+  ) ->
+  Int ->
+  [Bench.Benchmark]
+benchmarksTranformOn onLazy onStrict onChamp n =
+  [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf onLazy (buildN @HashMap n),
+    Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf onStrict (buildN @HashMap n),
+    Bench.bench ("HashMapBL." <> show n) $ Bench.nf onChamp (buildN @HashMapBL n),
+    Bench.bench ("HashMapBB." <> show n) $ Bench.nf onChamp (buildN @HashMapBB n),
+    Bench.bench ("HashMapBU." <> show n) $ Bench.nf onChamp (buildN @HashMapBU n),
+    Bench.bench ("HashMapUL." <> show n) $ Bench.nf onChamp (buildN @HashMapUL n),
+    Bench.bench ("HashMapUB." <> show n) $ Bench.nf onChamp (buildN @HashMapUB n),
+    Bench.bench ("HashMapUU." <> show n) $ Bench.nf onChamp (buildN @HashMapUU n)
+  ]
 
 -- myinsert :: Int -> Int -> MyLib.MapBL Int Int -> MyLib.MapBL Int Int
 -- {-# NOINLINE myinsert #-}

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -27,8 +27,10 @@ main =
     , foldrBench
     , foldl'SmallBench
     , foldl'Bench
-    , filterWithKeySmallBench
-    , filterWithKeyBench
+    , filterWithKeyBench [0..32]
+    , filterWithKeyBench (0 : powersOfTwo 13)
+    , mapMaybeWithKeyBench [0..32]
+    , mapMaybeWithKeyBench (0 : powersOfTwo 13)
     , toListSmallBench
     , toListBench
     ]
@@ -62,7 +64,7 @@ insertBench =
           Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUB n),
           Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.insert n n) (buildN @HashMapUU n)
         ]
-      | n <- ([0] <> powersOfTwo)
+      | n <- ([0] <> powersOfTwo 10)
       ]
 
 lookupSmallBench :: Bench.Benchmark
@@ -94,7 +96,7 @@ lookupBench =
           Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUB n),
           Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.lookup (n)) (buildN @HashMapUU n)
         ]
-      | n <- powersOfTwo
+      | n <- powersOfTwo 10
       ]
 
 lookupByteArraySmallBench :: Bench.Benchmark
@@ -126,7 +128,7 @@ lookupByteArrayBench =
           Bench.bench ("HashMapUlB." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlB n),
           Bench.bench ("HashMapUlU." <> show n) $ Bench.nf (Champ.HashMap.lookup (fromString (show n))) (buildBAN @HashMapUlU n)
         ]
-      | n <- powersOfTwo
+      | n <- powersOfTwo 10
       ]
 
 foldrSmallBench :: Bench.Benchmark
@@ -159,7 +161,7 @@ foldrBench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldr (+) 0) (buildN @HashMapUU n)
             ]
-          | n <- ([0] <> powersOfTwo)
+          | n <- ([0] <> powersOfTwo 10)
           ]
 
 foldl'SmallBench :: Bench.Benchmark
@@ -192,7 +194,7 @@ foldl'Bench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.foldl' (+) 0) (buildN @HashMapUU n)
             ]
-          | n <- ([0] <> powersOfTwo)
+          | n <- ([0] <> powersOfTwo 10)
           ]
 
 toListSmallBench :: Bench.Benchmark
@@ -225,15 +227,17 @@ toListBench =
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.toList) (buildN @HashMapUU n)
             ]
-          | n <- ([0] <> powersOfTwo)
+          | n <- ([0] <> powersOfTwo 10)
           ]
 
-filterWithKeySmallBench :: Bench.Benchmark
-filterWithKeySmallBench = do
+
+filterWithKeyBench :: [Int] -> Bench.Benchmark
+filterWithKeyBench ns = do
   let isEven _ v = even v
-  Bench.bgroup "filterWithKey (small)" $
+  Bench.bgroup "filterWithKey (powers of two)" $
      mconcat
-          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
+          [ [
+              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
               Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
               Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBL n),
               Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBB n),
@@ -242,26 +246,29 @@ filterWithKeySmallBench = do
               Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUB n),
               Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUU n)
             ]
-          | n <- [0..32]
+          | n <- ns
           ]
 
 
-filterWithKeyBench :: Bench.Benchmark
-filterWithKeyBench = do
-  let isEven _ v = even v
-  Bench.bgroup "filterWithKey (powers of two)" $
+mapMaybeWithKeyBench :: [Int] -> Bench.Benchmark
+mapMaybeWithKeyBench ns = do
+  let isEven _ v =
+        if even v
+          then Just v
+          else Nothing
+  Bench.bgroup "mapMaybeWithKey (powers of two)" $
      mconcat
           [ [
-              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
-              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBL n in inp),
-              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBB n in inp),
-              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBU n in inp),
-              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUL n in inp),
-              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUB n in inp),
-              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUU n in inp)
+              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.mapMaybeWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.mapMaybeWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBL n),
+              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBB n),
+              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapBU n),
+              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUL n),
+              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUB n),
+              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.mapMaybeWithKey isEven) (buildN @HashMapUU n)
             ]
-          | n <- ([0] <> powersOfTwo)
+          | n <- ns
           ]
 
 -- myinsert :: Int -> Int -> MyLib.MapBL Int Int -> MyLib.MapBL Int Int
@@ -286,5 +293,5 @@ buildN n = force $ fromList [(x, x) | x <- [0 .. (n - 1)]]
 buildBAN :: forall map. (NFData (map ShortText Int), IsList (map ShortText Int), Item (map ShortText Int) ~ (ShortText, Int)) => Int -> (map ShortText Int)
 buildBAN n = force $ fromList [(fromString (show x), x) | x <- [0 .. (n - 1)]]
 
-powersOfTwo :: [Int]
-powersOfTwo = [2 ^ (x :: Int) | x <- [0 .. 10]]
+powersOfTwo :: Int -> [Int]
+powersOfTwo n = [2 ^ (x :: Int) | x <- [0 .. n]]

--- a/bench/Bench.hs
+++ b/bench/Bench.hs
@@ -27,6 +27,8 @@ main =
     , foldrBench
     , foldl'SmallBench
     , foldl'Bench
+    , filterWithKeySmallBench
+    , filterWithKeyBench
     , toListSmallBench
     , toListBench
     ]
@@ -226,7 +228,41 @@ toListBench =
           | n <- ([0] <> powersOfTwo)
           ]
 
+filterWithKeySmallBench :: Bench.Benchmark
+filterWithKeySmallBench = do
+  let isEven _ v = even v
+  Bench.bgroup "filterWithKey (small)" $
+     mconcat
+          [ [ Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBL n),
+              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBB n),
+              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapBU n),
+              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUL n),
+              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUB n),
+              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (buildN @HashMapUU n)
+            ]
+          | n <- [0..32]
+          ]
 
+
+filterWithKeyBench :: Bench.Benchmark
+filterWithKeyBench = do
+  let isEven _ v = even v
+  Bench.bgroup "filterWithKey (powers of two)" $
+     mconcat
+          [ [
+              Bench.bench ("Data.HashMap.Lazy." <> show n) $ Bench.nf (Data.HashMap.Lazy.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("Data.HashMap.Strict." <> show n) $ Bench.nf (Data.HashMap.Strict.filterWithKey isEven) (buildN @HashMap n),
+              Bench.bench ("HashMapBL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBL n in inp),
+              Bench.bench ("HashMapBB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBB n in inp),
+              Bench.bench ("HashMapBU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapBU n in inp),
+              Bench.bench ("HashMapUL." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUL n in inp),
+              Bench.bench ("HashMapUB." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUB n in inp),
+              Bench.bench ("HashMapUU." <> show n) $ Bench.nf (Champ.HashMap.filterWithKey isEven) (let !inp = buildN @HashMapUU n in inp)
+            ]
+          | n <- ([0] <> powersOfTwo)
+          ]
 
 -- myinsert :: Int -> Int -> MyLib.MapBL Int Int -> MyLib.MapBL Int Int
 -- {-# NOINLINE myinsert #-}

--- a/champ.cabal
+++ b/champ.cabal
@@ -148,6 +148,7 @@ test-suite test
     build-depends:
         -- Library and datatypes to exercise during tests:
         base,
+        contiguous,
         unordered-containers,
         champ,
         -- Test framework:
@@ -183,7 +184,7 @@ benchmark bench
 
     -- Base language which the package is written in.
     default-language: GHC2021
-    ghc-options:   "-with-rtsopts=-A32m"
+    ghc-options:   "-with-rtsopts=-A32m" -rtsopts
     if impl(ghc >= 8.6)
         ghc-options: -fproc-alignment=64
     main-is:       Bench.hs

--- a/src/Champ/Internal.hs
+++ b/src/Champ/Internal.hs
@@ -286,7 +286,7 @@ bitposLocation node@(MapNode bitmap _ _ _) bitpos
   | (childrenBitmap node) .&. bitpos /= 0 = InChild
   | otherwise = Nowhere
 
--- \(O(n)\) Construct a map with the supplied key-value mappings.
+-- \(O(n \log32 n)\) Construct a map with the supplied key-value mappings.
 -- 
 -- If the list contains duplicate keys, later mappings take precedence.
 --
@@ -296,14 +296,14 @@ fromList :: (Hashable k, MapRepr keys vals k v) => [(k, v)] -> HashMap keys vals
 {-# INLINE fromList #-}
 fromList = Foldable.foldl' (\m (k, v) -> unsafeInsert k v m) empty
 
--- | \(O(n \log n)\) Construct a map from a list of elements.  Uses
+-- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
 -- the provided function @f@ to merge duplicate entries with
 -- @(f newVal oldVal)@.
 fromListWith :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
 {-# INLINE fromListWith #-}
 fromListWith f = List.foldl' (\m (k, v) -> unsafeInsertWith f k v m) empty
 
--- | \(O(n \log n)\) Construct a map from a list of elements.  Uses
+-- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
 -- the provided function @f@ to merge duplicate entries with
 -- @(f key newVal oldVal)@.
 fromListWithKey :: (Eq k, Hashable k, MapRepr keys vals k v) => (k -> v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
@@ -318,7 +318,7 @@ toList :: (MapRepr keys vals k v) => HashMap keys vals k v -> [(k, v)]
 {-# INLINE toList #-}
 toList hashmap = Exts.build (\fusedCons fusedNil -> foldrWithKey (\k v xs -> (k, v) `fusedCons` xs) fusedNil hashmap)
 
--- | \(O(\log n)\) Adjust the value tied to a given key in this map only
+-- | \(O(\log32 n)\) Adjust the value tied to a given key in this map only
 -- if it is present. Otherwise, leave the map alone.
 --
 -- The current implementation is very simple
@@ -332,7 +332,7 @@ adjust f k m =
       let v' = f v 
       in insert' Safe h k' v' m 
 
--- | \(O(\log n)\)  The expression @('alter' f k map)@ alters the value @x@ at @k@, or
+-- | \(O(\log32 n)\)  The expression @('alter' f k map)@ alters the value @x@ at @k@, or
 -- absence thereof.
 --
 -- 'alter' can be used to insert, delete, or update a value in a map.
@@ -357,14 +357,14 @@ alter f k m =
       Nothing -> delete' Safe h k' m
       Just v' -> if ptrEq v v' then m else insert' Safe h k' v' m
 
--- | \(O(\log n)\)  The expression @('update' f k map)@ updates the value @x@ at @k@
+-- | \(O(\log32 n)\)  The expression @('update' f k map)@ updates the value @x@ at @k@
 -- (if it is in the map). If @(f x)@ is 'Nothing', the element is deleted.
 -- If it is @('Just' y)@, the key @k@ is bound to the new value @y@.
 update :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> Maybe v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
 {-# INLINABLE update #-}
 update f = alter (>>= f)
 
--- | \(O(\log n)\)  The expression @('alterF' f k map)@ alters the value @x@ at
+-- | \(O(\log32 n)\)  The expression @('alterF' f k map)@ alters the value @x@ at
 -- @k@, or absence thereof.
 --
 --  'alterF' can be used to insert, delete, or update a value in a map.
@@ -393,7 +393,7 @@ alterF f = \ !k !m ->
           Nothing -> delete' Safe h k' m
           Just v' -> insert' Safe h k' v' m
 
--- | \(O(n)\).
+-- | \(O(n \log32 n)\).
 -- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
 --
 -- The size of the result may be smaller if @f@ maps two or more distinct

--- a/src/Champ/Internal/Array.hs
+++ b/src/Champ/Internal/Array.hs
@@ -62,13 +62,8 @@ import Data.Primitive.Unlifted.Class (PrimUnlifted (..), Unlifted)
 import Data.Primitive.Unlifted.Class qualified as Unlifted
 import Data.Primitive.Unlifted.SmallArray (SmallMutableUnliftedArray_ (..), SmallUnliftedArray_ (..), mapSmallUnliftedArray, unsafeThawSmallUnliftedArray, shrinkSmallMutableUnliftedArray)
 import Data.Primitive.Unlifted.SmallArray.Primops (SmallMutableUnliftedArray# (SmallMutableUnliftedArray#), SmallUnliftedArray# (SmallUnliftedArray#))
-import Numeric (showBin)
-import Data.Word
-import Unsafe.Coerce
 import GHC.Exts (SmallArray#, SmallMutableArray#)
 import Prelude hiding (foldl, foldl', foldr, length, null, read)
-import Debug.Trace
-import qualified GHC.Exts as Exts
 
 -- | Helper newtype to implement `PrimUnlifted` for any datatype
 -- to turn it into a `Data.Elevator.Strict`

--- a/test/suite/ConformanceTest.hs
+++ b/test/suite/ConformanceTest.hs
@@ -7,6 +7,7 @@
 module ConformanceTest where
 
 import Data.HashMap.Strict qualified
+import Control.Monad (forM_)
 import Champ
 import Champ.HashMap qualified
 import Champ.Internal qualified
@@ -26,7 +27,7 @@ tests :: TestLimit
 tests = 5000
 
 test_fromListToList :: [TestTree]
-test_fromListToList = 
+test_fromListToList =
     [ testProperty "toList . fromList conforms (HashMapBL)" $ propFromListToListConforms @HashMapBL
     , testProperty "toList . fromList conforms (HashMapBB)" $ propFromListToListConforms @HashMapBB
     , testProperty "toList . fromList conforms (HashMapBU)" $ propFromListToListConforms @HashMapBU
@@ -36,13 +37,23 @@ test_fromListToList =
     ]
 
 test_lookup :: [TestTree]
-test_lookup = 
+test_lookup =
     [ testProperty "lookup conforms (HashMapBL)" $ propLookupConforms @HashMapBL
     , testProperty "lookup conforms (HashMapBB)" $ propLookupConforms @HashMapBB
     , testProperty "lookup conforms (HashMapBU)" $ propLookupConforms @HashMapBU
     , testProperty "lookup conforms (HashMapUL)" $ propLookupConforms @HashMapUL
     , testProperty "lookup conforms (HashMapUB)" $ propLookupConforms @HashMapUB
     , testProperty "lookup conforms (HashMapUU)" $ propLookupConforms @HashMapUU
+    ]
+
+test_filterWithKey :: [TestTree]
+test_filterWithKey =
+    [ testProperty "filterWithKey conforms (HashMapBL)" $ propFilterWithKeyConforms @HashMapBL
+    , testProperty "filterWithKey conforms (HashMapBB)" $ propFilterWithKeyConforms @HashMapBB
+    , testProperty "filterWithKey conforms (HashMapBU)" $ propFilterWithKeyConforms @HashMapBU
+    , testProperty "filterWithKey conforms (HashMapUL)" $ propFilterWithKeyConforms @HashMapUL
+    , testProperty "filterWithKey conforms (HashMapUB)" $ propFilterWithKeyConforms @HashMapUB
+    , testProperty "filterWithKey conforms (HashMapUU)" $ propFilterWithKeyConforms @HashMapUU
     ]
 
 propFromListToListConforms :: forall champmap keys vals. 
@@ -93,3 +104,50 @@ propLookupConforms = withTests tests $ property $ do
 
     Data.HashMap.Strict.lookup key hs === Champ.HashMap.lookup key cs
     -- Champ.HashMap.lookup key cs === Champ.HashMap.lookup key cs
+
+propFilterWithKeyConforms :: forall champmap keys vals.
+    (champmap ~ HashMap keys vals
+    , MapRepr keys vals Int Int
+    , IsList (champmap Int Int)
+    , Item (champmap Int Int) ~ (Int, Int)
+    , Show (Champ.Internal.Storage.ArrayOf (Strict keys) Int)
+    , Show (Champ.Internal.Storage.ArrayOf vals Int)
+    )
+    => Property
+propFilterWithKeyConforms = withTests tests $ property $ do
+    let n = 1024
+    listInp <- forAll $ Gen.list (Range.linear 0 n) $ do
+        x <- (Gen.int (Range.linear 1 n))
+        b <- Gen.bool
+        pure (x, b)
+
+    let ks = [x | (x, _) <- listInp]
+    let kvs = zip ks ks
+    let fn k _ = Data.HashMap.Strict.lookupDefault (error "impossible") k $
+            Data.HashMap.Strict.fromList listInp
+    annotateShow kvs
+
+    let hs = fromList kvs
+    let cs = fromList kvs :: champmap Int Int
+
+    annotateShow hs
+    annotateShow cs
+    annotate (Champ.Internal.debugShow cs)
+
+    let hsFiltered = Data.HashMap.Strict.filterWithKey fn hs
+    let csFiltered = Champ.HashMap.filterWithKey fn cs
+    annotateShow hsFiltered
+    annotateShow csFiltered
+    annotate (Champ.Internal.debugShow csFiltered)
+
+    -- Check that the hashmaps contain the same things
+    sort (Data.HashMap.Strict.toList hsFiltered) === sort (Champ.HashMap.toList csFiltered)
+    -- Check that champ contains the correct structure.
+    forM_ ks $ \k -> do
+        Data.HashMap.Strict.lookup k hsFiltered === (Champ.HashMap.lookup k csFiltered)
+
+    -- Check that we didn't mutate anything the unfiltered pointed to.
+    sort (Data.HashMap.Strict.toList hs) === sort (Champ.HashMap.toList cs)
+    -- Check that champ contains the correct structure.
+    forM_ ks $ \k -> do
+        Data.HashMap.Strict.lookup k hs === (Champ.HashMap.lookup k cs)


### PR DESCRIPTION
Continuation of https://github.com/Qqwy/haskell-champ/pull/19. Can't point to my own PRs, so the base branch of this PR is wrong. It's supposed to point on top of #19.

Pulled out what I did for `filterWithKey`, made it generic, and applied it to `mapMaybeWithKey`. This is a bit more prone to fragmentation, due to me creating the value array at the same time as the boolean mask, instead of after.

Also took the liberty to clean up the benchmarks a tiny bit.

<details><summary>Benchmarks</summary>

```
  mapMaybeWithKey (powers of two)
    Data.HashMap.Lazy.1:      OK
      14.6 ns ± 668 ps,  31 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.1:    OK
      14.4 ns ± 780 ps,  31 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.1:              OK
      13.7 ns ± 928 ps,  79 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.1:              OK
      12.3 ns ± 432 ps,  79 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.1:              OK
      12.9 ns ± 1.2 ns,  79 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.1:              OK
      13.7 ns ± 1.3 ns,  79 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.1:              OK
      12.3 ns ± 576 ps,  79 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.1:              OK
      11.7 ns ± 674 ps,  79 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.2:      OK
      33.0 ns ± 2.0 ns,  63 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.2:    OK
      32.9 ns ± 1.8 ns,  63 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.2:              OK
      52.2 ns ± 4.3 ns, 220 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.2:              OK
      53.6 ns ± 3.7 ns, 204 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.2:              OK
      42.4 ns ± 2.0 ns, 197 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.2:              OK
      51.8 ns ± 3.6 ns, 234 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.2:              OK
      52.4 ns ± 3.4 ns, 222 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.2:              OK
      42.0 ns ± 1.7 ns, 213 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.4:      OK
      58.1 ns ± 3.7 ns,  95 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.4:    OK
      58.3 ns ± 2.9 ns,  95 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.4:              OK
      85.9 ns ± 7.4 ns, 279 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.4:              OK
      85.8 ns ± 5.2 ns, 318 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.4:              OK
      71.0 ns ± 6.4 ns, 279 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.4:              OK
      80.3 ns ± 6.6 ns, 279 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.4:              OK
      79.7 ns ± 7.4 ns, 318 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.4:              OK
      62.7 ns ± 5.8 ns, 253 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.8:      OK
      96.8 ns ± 1.7 ns, 133 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.8:    OK
      97.0 ns ± 8.3 ns, 127 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.8:              OK
      131  ns ± 6.2 ns, 382 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.8:              OK
      129  ns ±  12 ns, 431 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.8:              OK
      104  ns ± 7.3 ns, 382 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.8:              OK
      121  ns ±  10 ns, 382 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.8:              OK
      117  ns ± 6.7 ns, 444 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.8:              OK
      92.8 ns ± 7.7 ns, 344 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.16:     OK
      187  ns ±  12 ns, 176 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.16:   OK
      189  ns ±  10 ns, 176 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.16:             OK
      231  ns ±  23 ns, 506 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.16:             OK
      215  ns ±  16 ns, 685 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.16:             OK
      176  ns ± 7.7 ns, 595 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.16:             OK
      207  ns ±  11 ns, 557 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.16:             OK
      190  ns ±  18 ns, 685 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.16:             OK
      153  ns ±  15 ns, 554 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.32:     OK
      337  ns ±  33 ns, 254 B  allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.32:   OK
      339  ns ±  20 ns, 254 B  allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.32:             OK
      424  ns ±  23 ns, 1.0 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.32:             OK
      401  ns ±  37 ns, 1.1 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.32:             OK
      320  ns ±  13 ns, 1.0 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.32:             OK
      377  ns ±  31 ns, 1.0 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.32:             OK
      356  ns ±  21 ns, 1.1 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.32:             OK
      291  ns ±  21 ns, 1.0 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.64:     OK
      1.19 μs ± 104 ns, 1.3 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.64:   OK
      1.19 μs ± 116 ns, 1.3 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.64:             OK
      1.74 μs ± 173 ns, 6.7 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.64:             OK
      1.78 μs ± 106 ns, 6.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.64:             OK
      1.52 μs ± 131 ns, 6.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.64:             OK
      1.75 μs ± 136 ns, 6.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.64:             OK
      1.70 μs ±  82 ns, 7.1 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.64:             OK
      1.45 μs ± 108 ns, 6.9 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.128:    OK
      1.82 μs ± 180 ns, 2.0 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.128:  OK
      1.76 μs ±  97 ns, 2.0 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.128:            OK
      2.21 μs ± 217 ns, 7.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBB.128:            OK
      2.23 μs ± 211 ns, 7.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.128:            OK
      1.82 μs ± 169 ns, 7.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUL.128:            OK
      2.22 μs ± 195 ns, 7.9 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.128:            OK
      2.07 μs ± 153 ns, 8.3 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.128:            OK
      1.76 μs ± 147 ns, 8.3 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.256:    OK
      3.09 μs ± 131 ns, 3.0 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.256:  OK
      3.14 μs ± 287 ns, 2.8 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBL.256:            OK
      3.16 μs ± 228 ns,  11 KB allocated,   1 B  copied,  35 MB peak memory
    HashMapBB.256:            OK
      3.13 μs ± 244 ns,  11 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapBU.256:            OK
      2.38 μs ± 142 ns,  11 KB allocated,   1 B  copied,  35 MB peak memory
    HashMapUL.256:            OK
      3.08 μs ± 150 ns,  11 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUB.256:            OK
      2.87 μs ± 284 ns,  11 KB allocated,   0 B  copied,  35 MB peak memory
    HashMapUU.256:            OK
      2.28 μs ± 111 ns,  11 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Lazy.512:    OK
      5.83 μs ± 349 ns, 3.9 KB allocated,   0 B  copied,  35 MB peak memory
    Data.HashMap.Strict.512:  OK
      5.88 μs ± 476 ns, 3.9 KB allocated,   0 B  copied,  36 MB peak memory
    HashMapBL.512:            OK
      5.07 μs ± 283 ns,  17 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapBB.512:            OK
      4.91 μs ± 187 ns,  17 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapBU.512:            OK
      3.59 μs ± 321 ns,  17 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapUL.512:            OK
      5.02 μs ± 260 ns,  17 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapUB.512:            OK
      4.62 μs ± 355 ns,  16 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapUU.512:            OK
      3.53 μs ± 179 ns,  17 KB allocated,   1 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.1024:   OK
      10.6 μs ± 699 ns, 8.0 KB allocated,   1 B  copied,  36 MB peak memory
    Data.HashMap.Strict.1024: OK
      10.6 μs ± 680 ns, 8.0 KB allocated,   1 B  copied,  36 MB peak memory
    HashMapBL.1024:           OK
      9.49 μs ± 693 ns,  27 KB allocated,   3 B  copied,  36 MB peak memory
    HashMapBB.1024:           OK
      8.71 μs ± 487 ns,  29 KB allocated,   3 B  copied,  36 MB peak memory
    HashMapBU.1024:           OK
      6.13 μs ± 332 ns,  28 KB allocated,   3 B  copied,  36 MB peak memory
    HashMapUL.1024:           OK
      9.12 μs ± 846 ns,  27 KB allocated,   3 B  copied,  36 MB peak memory
    HashMapUB.1024:           OK
      8.14 μs ± 755 ns,  27 KB allocated,   3 B  copied,  36 MB peak memory
    HashMapUU.1024:           OK
      5.99 μs ± 427 ns,  28 KB allocated,   3 B  copied,  36 MB peak memory
    Data.HashMap.Lazy.2048:   OK
      37.4 μs ± 2.9 μs,  43 KB allocated,   6 B  copied,  37 MB peak memory
    Data.HashMap.Strict.2048: OK
      37.4 μs ± 3.0 μs,  43 KB allocated,   9 B  copied,  37 MB peak memory
    HashMapBL.2048:           OK
      57.2 μs ± 5.3 μs, 190 KB allocated, 154 B  copied,  37 MB peak memory
    HashMapBB.2048:           OK
      58.8 μs ± 3.7 μs, 222 KB allocated, 160 B  copied,  37 MB peak memory
    HashMapBU.2048:           OK
      49.3 μs ± 3.9 μs, 203 KB allocated, 136 B  copied,  38 MB peak memory
    HashMapUL.2048:           OK
      57.2 μs ± 4.3 μs, 203 KB allocated, 139 B  copied,  38 MB peak memory
    HashMapUB.2048:           OK
      57.1 μs ± 3.0 μs, 222 KB allocated, 155 B  copied,  38 MB peak memory
    HashMapUU.2048:           OK
      44.5 μs ± 4.0 μs, 203 KB allocated, 167 B  copied,  38 MB peak memory
    Data.HashMap.Lazy.4096:   OK
      57.5 μs ± 3.5 μs,  64 KB allocated,  48 B  copied,  39 MB peak memory
    Data.HashMap.Strict.4096: OK
      58.2 μs ± 5.8 μs,  64 KB allocated,  32 B  copied,  40 MB peak memory
    HashMapBL.4096:           OK
      72.8 μs ± 6.2 μs, 254 KB allocated, 166 B  copied,  40 MB peak memory
    HashMapBB.4096:           OK
      74.3 μs ± 3.4 μs, 266 KB allocated, 246 B  copied,  40 MB peak memory
    HashMapBU.4096:           OK
      60.3 μs ± 3.1 μs, 254 KB allocated, 207 B  copied,  41 MB peak memory
    HashMapUL.4096:           OK
      73.3 μs ± 3.3 μs, 254 KB allocated, 210 B  copied,  41 MB peak memory
    HashMapUB.4096:           OK
      71.1 μs ± 3.3 μs, 266 KB allocated, 236 B  copied,  42 MB peak memory
    HashMapUU.4096:           OK
      54.3 μs ± 3.9 μs, 254 KB allocated, 192 B  copied,  42 MB peak memory
    Data.HashMap.Lazy.8192:   OK
      102  μs ± 5.7 μs,  88 KB allocated,  95 B  copied,  43 MB peak memory
    Data.HashMap.Strict.8192: OK
      102  μs ± 7.2 μs,  88 KB allocated,  91 B  copied,  44 MB peak memory
    HashMapBL.8192:           OK
      108  μs ± 5.3 μs, 342 KB allocated, 343 B  copied,  45 MB peak memory
    HashMapBB.8192:           OK
      104  μs ± 9.9 μs, 343 KB allocated, 380 B  copied,  45 MB peak memory
    HashMapBU.8192:           OK
      80.5 μs ± 5.8 μs, 342 KB allocated, 344 B  copied,  46 MB peak memory
    HashMapUL.8192:           OK
      106  μs ± 6.9 μs, 342 KB allocated, 343 B  copied,  47 MB peak memory
    HashMapUB.8192:           OK
      97.9 μs ± 9.0 μs, 343 KB allocated, 384 B  copied,  47 MB peak memory
    HashMapUU.8192:           OK
      73.2 μs ± 3.3 μs, 349 KB allocated, 343 B  copied,  48 MB peak memory
```

</details>