### PR TITLE
Improved documentation formatting

### DIFF
--- a/src/Champ/HashMap.hs
+++ b/src/Champ/HashMap.hs
@@ -15,7 +15,6 @@ module Champ.HashMap (
     Champ.Internal.HashMapUlUl,
     -- * Generic type
     Champ.Internal.HashMap,
-    Champ.Internal.Storage.Storage(..),
     Champ.Internal.MapRepr,
     -- * Construction
     Champ.Internal.empty,
@@ -102,7 +101,10 @@ module Champ.HashMap (
 
     -- ** HashSets
     Champ.HashSet.keysSet,
-    Champ.HashSet.keysSet'
+    Champ.HashSet.keysSet',
+    -- * Generic type details
+    Champ.Internal.Storage.Storage(..),
+    Champ.Internal.Storage.StrictStorage(..)
 ) where
 
 import GHC.Stack (HasCallStack)

--- a/src/Champ/HashSet.hs
+++ b/src/Champ/HashSet.hs
@@ -9,8 +9,6 @@ module Champ.HashSet (
     HashSetUl,
     -- ** Generic type
     HashSet(..),
-    Champ.Internal.Storage.Storage(Unexistent),
-    Champ.Internal.Storage.StrictStorage(..),
     SetRepr,
     -- * Construction
     empty,
@@ -54,7 +52,10 @@ module Champ.HashSet (
     toMap,
     fromMap,
     keysSet,
-    keysSet'
+    keysSet',
+    -- * Generic type details
+    Champ.Internal.Storage.Storage(Unexistent),
+    Champ.Internal.Storage.StrictStorage(..),
 ) where
 
 import Prelude hiding (map, foldr, lookup)

--- a/src/Champ/Internal.hs
+++ b/src/Champ/Internal.hs
@@ -230,7 +230,7 @@ isNonZeroBitmap b = (# | b #)
 --
 -- Conceptually, you can think of it as:
 --
--- ```
+-- @
 -- data Map (keys :: StrictStorage) (vals :: Storage) k v
 --  = EmptyMap 
 --  | SingletonMap !k v 
@@ -239,7 +239,8 @@ isNonZeroBitmap b = (# | b #)
 -- data MapNode keys vals k v
 --    = CollisionNode !(ArrayOf (Strict keys)) !(ArrayOf vals)
 --    | CompactNode !Bitmap !Bitmap !(ArrayOf (Strict keys)) !(ArrayOf vals) !(StrictSmallArray (MapNode keys vals k v))
--- ```
+-- @
+--
 -- with the following tricks:
 -- - We only store a single 64-bit bitmap (taking up one word) rather than two separate 32-bit bitmaps,
 --  and use its lower/higher 32 bits using masking and shifting instead, saving one word per map node.


### PR DESCRIPTION
- [x] Ensures the conceptual internal structure of the Champ datatype is formatted nicely in Haddock
- [x] Moves the exports of `Storage`/`StrictStorage` to the bottom of the `HashMap`/`HashSet` files as they are not that important to manipulate directly as normal users of the library.