### PR TITLE
Make Champ compile on GHC 9.6

### DIFF
--- a/champ-core/champ-core.cabal
+++ b/champ-core/champ-core.cabal
@@ -51,7 +51,7 @@ build-type:         Simple
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC == { 9.8.4, 9.10.1 }
+tested-with: GHC == { 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 common warnings
     ghc-options: -Wall -pgmPcpphs -optP--cpp

--- a/champ-core/src/Champ/Internal/Array.hs
+++ b/champ-core/src/Champ/Internal/Array.hs
@@ -63,7 +63,8 @@ import Data.Primitive.Unlifted.Class qualified as Unlifted
 import Data.Primitive.Unlifted.SmallArray (SmallMutableUnliftedArray_ (..), SmallUnliftedArray_ (..), mapSmallUnliftedArray, unsafeThawSmallUnliftedArray, shrinkSmallMutableUnliftedArray)
 import Data.Primitive.Unlifted.SmallArray.Primops (SmallMutableUnliftedArray# (SmallMutableUnliftedArray#), SmallUnliftedArray# (SmallUnliftedArray#))
 import GHC.Exts (SmallArray#, SmallMutableArray#)
-import Prelude hiding (foldl, foldl', foldr, length, null, read)
+
+import Prelude hiding (foldl, foldr, length, null, read)
 
 -- | Helper newtype to implement `PrimUnlifted` for any datatype,
 -- part of making `StrictSmallArray`/`StrictSmallMutableArray` work for any `a`.

--- a/champ/champ.cabal
+++ b/champ/champ.cabal
@@ -51,7 +51,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC == { 9.8.4, 9.10.1 }
+tested-with: GHC == { 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 common warnings
     ghc-options: -Wall -pgmPcpphs -optP--cpp


### PR DESCRIPTION
- [x] Extends the `tested-with` to include GHC 9.6 and 9.12
- [x] Rewrite some pattern matches on `UnliftedType`s to use continuation-passing-style instead, since GHC 9.6 otherwise cannot handle them


Fixes #11 