### PR TITLE
Now without data families repro

### DIFF
--- a/champ-core/champ-core.cabal
+++ b/champ-core/champ-core.cabal
@@ -54,7 +54,8 @@ build-type:         Simple
 tested-with: GHC == { 9.6.7, 9.8.4, 9.10.1, 9.12.2 }
 
 common warnings
-    ghc-options: -Wall -pgmPcpphs -optP--cpp
+    -- ghc-options: -Wall -pgmPcpphs -optP--cpp
+    ghc-options: -Wall
 
 library
     -- Import common warning flags.
@@ -86,7 +87,7 @@ library
       template-haskell,
       text-short,
 
-    build-tool-depends: cpphs:cpphs
+    -- build-tool-depends: cpphs:cpphs
 
     -- Directories containing source files.
     hs-source-dirs:   src

--- a/champ-core/src/Champ/Internal.hs
+++ b/champ-core/src/Champ/Internal.hs
@@ -1,82 +1,216 @@
-{-# LANGUAGE GHC2021 #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UnliftedNewtypes #-}
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MagicHash #-}
-{-# LANGUAGE MultiWayIf #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RoleAnnotations #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UnboxedTuples #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -ddump-simpl -ddump-cmm -ddump-stg-tags -ddump-stg-final -ddump-asm -ddump-to-file #-}
 {-# LANGUAGE ViewPatterns #-}
--- {-# OPTIONS_GHC -ddump-simpl -dsuppress-all -dsuppress-uniques -ddump-stg-from-core -ddump-cmm -ddump-to-file #-}
-{-# OPTIONS_GHC -funbox-strict-fields -O2 #-}
-
--- We'd really like to use the names 'keys', 'elems', 'vals'
--- for a bunch of different things.
-{-# OPTIONS_GHC -Wno-name-shadowing #-}
-
+{-# LANGUAGE UnliftedDatatypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MonoLocalBinds #-} -- ???
+{-# LANGUAGE UndecidableSuperClasses #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE TypeFamilies #-}
 module Champ.Internal where
 
-import Champ.Internal.Array (Array, StrictSmallArray, IsUnit, PrimUnlifted, Safety(..))
-import Champ.Internal.Array qualified as Array
-import Champ.Internal.Collision qualified as Collision
-import Champ.Internal.Storage (ArrayOf, Storage (..), StrictStorage (..), Soloist(..))
-import Champ.Internal.Util (ptrEq)
-import Control.Monad qualified
-import Data.Bits hiding (shift)
-import Data.Foldable qualified as Foldable
-import Data.Function ((&))
+import Prelude hiding (lookup, null)
+import GHC.Exts (UnliftedType, Any)
+import GHC.Exts qualified as Exts
+import GHC.Word (Word64)
+import Data.Bits (Bits, FiniteBits)
+import Control.DeepSeq (NFData (rnf))
+import Champ.Internal.Storage (Storage(..), ArrayOf, StrictStorage (..), Soloist(..))
+import Champ.Internal.Array (StrictSmallArray, Array, PrimUnlifted, IsUnit, Safety (..))
+import Unsafe.Coerce (unsafeCoerce)
+import Data.Primitive.Contiguous qualified as Contiguous
+import Data.Kind (Type)
 import Data.Hashable (Hashable)
 import Data.Hashable qualified as Hashable
-import Data.List qualified as List
+import Data.Coerce (coerce)
 import Data.Primitive (Prim)
 import Data.Primitive.Contiguous (Element)
-import Data.Primitive.Contiguous qualified as Contiguous
-import Data.Word (Word64, Word32)
-import GHC.Exts qualified as Exts
-import GHC.IsList (IsList (..))
+import Data.Bits hiding (shift)
+import qualified Champ.Internal.Array as Array
+import Data.Function ((&))
+import Champ.Internal.Util (ptrEq)
+import qualified Champ.Internal.Collision as Collision
+import GHC.IsList (IsList)
+import qualified Data.Foldable as Foldable
+import qualified Data.List as List
 import Numeric (showBin)
-import Prelude hiding (null, lookup, filter)
-import Data.Coerce (Coercible)
-import Data.Type.Coercion qualified
-import Unsafe.Coerce (unsafeCoerce)
-import Data.Type.Coercion (Coercion(Coercion))
-import GHC.Exts (Any)
-import Control.DeepSeq
-
--- * Setup
---
--- $setup
---
--- It is recommended to import the types from the main `Champ` module
--- and import `Champ.HashMap` and `Champ.HashSet` qualified,
--- since they contain many functions that would conflict
--- with hashmap-specific versions of same-named functions in the Prelude.
--- 
--- >>> import Champ
--- >>> import Champ.HashMap qualified
--- >>> import Champ.HashSet qualified
---
--- To reduce boilerplate, you can use `OverloadedLists`
--- to build hashmaps directly from a list containing key-value pairs (and hashsets from a list of elements).
--- This will automatically call `Champ.HashMap.toList`.
--- >>> :set -XOverloadedLists
---
--- Some examples also use the following extensions:
--- >>> :set -XOverloadedStrings
---
--- The following types from other libraries
--- are used in some examples:
--- >>> import Data.Text.Short (ShortText) -- from the @text-short@ library
+import qualified Control.Monad
+import Data.Word (Word32)
 
 #define BIT_PARTITION_SIZE 5
 #define HASH_CODE_LENGTH (1 `unsafeShiftL` BIT_PARTITION_SIZE)
 #define BIT_PARTITION_MASK (HASH_CODE_LENGTH - 1)
+
+newtype Box :: UnliftedType where
+    Box :: Any @UnliftedType -> Box
+
+-- newtype Box = Box (Any @UnliftedType)
+-- type Box = (Any @UnliftedType)
+
+
+toBox :: forall a. a -> Box
+{-# INLINE toBox #-}
+toBox a = a `seq` Exts.unsafeCoerce# a
+
+unBox :: forall a. Box -> a
+{-# INLINE unBox #-}
+unBox a = Exts.unsafeCoerce# a
+-- toBox :: a -> Box
+-- toBox = unsafeCoerce id
+
+-- unBox :: Box -> a
+-- unBox = unsafeCoerce id
+
+data HashMap ks vs k v = HashMap
+  -- The size
+  {-# UNPACK #-} !Word
+  -- The root node
+  {-# UNPACK #-} !(MapNode ks vs k v)
+
+type role MapNode nominal nominal nominal representational
+type MapNode :: StrictStorage -> Storage -> Type -> Type -> Type
+data MapNode ks vs k v = MapNode
+    -- Indicates which parts of the node are occupied:
+    {-# UNPACK #-} !Bitmap
+    {-# UNPACK #-} !Box
+    {-# UNPACK #-} !Box
+    {-# UNPACK #-} !(StrictSmallArray (MapNode ks vs k v))
+    -- -- Stores keys
+    -- {-# UNPACK #-} !Box
+    -- -- Stores values
+    -- {-# UNPACK #-} !Box
+    -- -- Stores child nodes
+    -- {-# UNPACK #-} !Box
+
+
+-- Inside a MapNode,
+-- the lower 32 bits indicate the inline leaves
+-- and the higher 32 bits indicate child nodes
+newtype Bitmap = Bitmap Word64
+  deriving (Eq, Ord, Num, Bits, Enum, Real, Integral, FiniteBits, NFData)
+
+instance Show Bitmap where
+  -- \| Shows a bitmap in binary, with the lowest bit on the left
+  -- and always padded to 32 bits
+  show :: Bitmap -> String
+  show bitmap = "( " <> show32 bitmap <> ", " <> show32 (bitmap `unsafeShiftR` HASH_CODE_LENGTH) <> ")"
+    where
+      show32 b = take 32 $ reverse (showBin b "") <> repeat '0'
+
+class (Array (ArrayOf (Strict ks)), Array (ArrayOf vs), Element (ArrayOf (Strict ks)) k, Element (ArrayOf vs) v, Soloist vs) => MapRepr ks vs k v where
+instance MapRepr Boxed Lazy k v where
+instance MapRepr Boxed (Strict Boxed) k v where
+instance (PrimUnlifted v) => MapRepr Boxed (Strict Unlifted) k v where
+instance (Prim v) => MapRepr Boxed (Strict Unboxed) k v where
+instance (IsUnit v) => MapRepr Boxed Unexistent k v where
+
+instance (Prim k) => MapRepr Unboxed Lazy k v where
+instance (Prim k) => MapRepr Unboxed (Strict Boxed) k v where
+instance (Prim k, PrimUnlifted v) => MapRepr Unboxed (Strict Unlifted) k v where
+instance (Prim k, Prim v) => MapRepr Unboxed (Strict Unboxed) k v where
+instance (Prim k, IsUnit v) => MapRepr Unboxed Unexistent k v where
+
+instance (PrimUnlifted k) => MapRepr Unlifted Lazy k v where
+instance (PrimUnlifted k) => MapRepr Unlifted (Strict Boxed) k v where
+instance (PrimUnlifted k, PrimUnlifted v) => MapRepr Unlifted (Strict Unlifted) k v where
+instance (PrimUnlifted k, Prim v) => MapRepr Unlifted (Strict Unboxed) k v where
+instance (PrimUnlifted k, IsUnit v) => MapRepr Unlifted Unexistent k v where
+
+emptyMap :: forall ks vs k v. MapRepr ks vs k v => HashMap ks vs k v
+emptyMap =
+    let emptyBitmap = 0
+        emptyKeys = toBox (Contiguous.empty :: (ArrayOf (Strict ks) k))
+        emptyVals = toBox (Contiguous.empty :: (ArrayOf vs v))
+        emptyChildren = (Contiguous.empty :: StrictSmallArray (MapNode ks vs k v))
+    in
+        HashMap 0 (MapNode emptyBitmap emptyKeys emptyVals emptyChildren)
+
+singletonMap :: forall ks vs k v. MapRepr ks vs k v => Hash -> k -> v -> HashMap ks vs k v
+singletonMap !h !k v =
+    let singleHash = (coerce h)
+        singleKey = toBox (solo @(Strict ks) k)
+        singleVal = toBox (solo @vs v)
+        emptyChildren = (Contiguous.empty :: StrictSmallArray (MapNode ks vs k v))
+    in
+        HashMap 1 (MapNode singleHash singleKey singleVal emptyChildren)
+
+
+manyMap :: forall ks vs k v. MapRepr ks vs k v => Word -> MapNode ks vs k v -> HashMap ks vs k v
+manyMap !s !node = HashMap s node
+
+pattern EmptyMap :: forall ks vs k v. MapRepr ks vs k v => HashMap ks vs k v
+{-# INLINE EmptyMap #-}
+pattern EmptyMap <- HashMap 0 (MapNode _ _ _ _)
+    where
+        EmptyMap = emptyMap
+
+pattern SingletonMap :: forall ks vs k v. MapRepr ks vs k v => Hash -> k -> v -> HashMap ks vs k v
+{-# INLINE SingletonMap #-}
+-- pattern SingletonMap h k v <- HashMap 1 (MapNode (coerce -> h) (unBox @k -> k) (unBox @(SoloType vs v) -> unSolo @vs -> v) _)
+pattern SingletonMap h k v <- HashMap 1 (MapNode (coerce -> h) (unBox -> k) (unBox @(SoloType vs v) -> unSolo @vs @v -> v) _)
+    where
+        SingletonMap !h !k v =
+            let singleHash = (coerce h)
+                singleKey = toBox (solo @(Strict ks) k)
+                singleVal = toBox (solo @vs v)
+                emptyChildren = (Contiguous.empty :: StrictSmallArray (MapNode ks vs k v))
+            in
+                HashMap 1 (MapNode singleHash singleKey singleVal emptyChildren)
+
+boom :: forall (a :: UnliftedType) b. a -> b
+boom = error "boom"
+
+-- unKey :: forall k. Box -> k
+-- -- Without this NOINLINE we get an internal compiler error
+-- {-# NOINLINE unKey #-}
+-- unKey k = unBox @k k
+
+pattern ManyMap :: forall ks vs k v. MapRepr ks vs k v => Word -> MapNode ks vs k v -> HashMap ks vs k v
+{-# INLINE ManyMap #-}
+pattern ManyMap s node <- HashMap (bigSize -> (True, s)) node
+    where
+        ManyMap !s !node = manyMap s node
+
+bigSize :: Word -> (Bool, Word)
+bigSize s = (s > 1, s)
+
+pattern CollisionNode :: forall ks vs k v. (MapRepr ks vs k v) => (ArrayOf (Strict ks) k) -> (ArrayOf vs) v -> MapNode ks vs k v
+{-# INLINE CollisionNode #-}
+pattern CollisionNode keys vals <- MapNode 0 (unBox -> keys) (unBox -> vals) _
+  where
+    CollisionNode !keys !vals = 
+        let !children = Contiguous.empty :: StrictSmallArray (MapNode ks vs k v)
+        in
+        MapNode 0 (toBox keys) (toBox vals) children
+
+pattern CompactNode :: forall ks vs k v. (MapRepr ks vs k v) => Bitmap -> (ArrayOf (Strict ks) k) -> (ArrayOf vs) v -> StrictSmallArray (MapNode ks vs k v) -> MapNode ks vs k v
+{-# INLINE CompactNode #-}
+pattern CompactNode bitmap keys vals children <- MapNode (isNonZeroBitmap -> (True, bitmap)) (unBox -> keys) (unBox -> vals) children
+  where
+    CompactNode !bitmap !keys !vals !children = MapNode bitmap (toBox keys) (toBox vals) children
+
+{-# COMPLETE CollisionNode, CompactNode #-}
+
+isNonZeroBitmap :: Bitmap -> (Bool, Bitmap)
+{-# INLINE isNonZeroBitmap #-}
+isNonZeroBitmap (Bitmap 0) = (False, Bitmap 0)
+isNonZeroBitmap (Bitmap b) = (True, Bitmap b)
+
+newtype Mask = Mask Word
+  deriving (Eq, Ord, Show)
+
+newtype Hash = Hash Word64
+  deriving (Eq, Ord, Show)
+
+{-# COMPLETE EmptyMap, SingletonMap, ManyMap #-}
+
 
 -- * Boxed keys: 
 
@@ -165,373 +299,85 @@ type HashMapUlU = HashMap Unlifted (Strict Unboxed)
 -- but requires the keys and values to implement `PrimUnlifted`.
 type HashMapUlUl = HashMap Unlifted (Strict Unlifted)
 
-pattern EmptyMap ::
-  forall (keyStorage :: StrictStorage) (valStorage :: Storage) k v.
-  (MapRepr keyStorage valStorage k v) =>
-  HashMap keyStorage valStorage k v
-{-# INLINE EmptyMap #-}
-pattern EmptyMap <- (matchMap -> (# (# #) | | #))
-  where
-    EmptyMap = emptyMap
-
-pattern SingletonMap ::
-  forall (keyStorage :: StrictStorage) (valStorage :: Storage) k v.
-  (MapRepr keyStorage valStorage k v) =>
-  Hash -> k -> v -> HashMap keyStorage valStorage k v
-{-# INLINE SingletonMap #-}
-pattern SingletonMap h k v <- (matchMap -> (# | (# h, k, v #) | #))
-  where
-    SingletonMap = singletonMap
-
-pattern ManyMap ::
-  forall (keyStorage :: StrictStorage) (valStorage :: Storage) k v.
-  (MapRepr keyStorage valStorage k v) =>
-  Word -> MapNode keyStorage valStorage k v -> HashMap keyStorage valStorage k v
-{-# INLINE ManyMap #-}
-pattern ManyMap mapsize node <- (matchMap -> (# | | (# mapsize, node #) #))
-  where
-    ManyMap = manyMap
-
-{-# COMPLETE EmptyMap, SingletonMap, ManyMap #-}
-
-{-# INLINE MapNode #-}
-pattern MapNode :: (MapRepr keyStorage valStorage k v) => Bitmap -> (ArrayOf (Strict keyStorage) k) -> (ArrayOf valStorage) v -> StrictSmallArray (MapNode keyStorage valStorage k v) -> MapNode keyStorage valStorage k v
-pattern MapNode bitmap keys vals children <- (unpackNode -> (# bitmap, keys, vals, children #))
-  where
-    MapNode bitmap keys vals children = packNode (# bitmap, keys, vals, children #)
-
-pattern CollisionNode :: (MapRepr keyStorage valStorage k v) => (ArrayOf (Strict keyStorage) k) -> (ArrayOf valStorage) v -> MapNode keyStorage valStorage k v
-{-# INLINE CollisionNode #-}
-pattern CollisionNode keys vals <- (unpackNode -> (# (== 0) -> True, keys, vals, _ #))
-  where
-    CollisionNode keys vals = packNode (# 0, keys, vals, Contiguous.empty #)
-
-pattern CompactNode :: (MapRepr keyStorage valStorage k v) => Bitmap -> (ArrayOf (Strict keyStorage) k) -> (ArrayOf valStorage) v -> StrictSmallArray (MapNode keyStorage valStorage k v) -> MapNode keyStorage valStorage k v
-{-# INLINE CompactNode #-}
-pattern CompactNode bitmap keys vals children <- (unpackNode -> (# (isNonZeroBitmap -> (# | bitmap #)), keys, vals, children #))
-  where
-    CompactNode bitmap keys vals children = packNode (# bitmap, keys, vals, children #)
-
-{-# INLINE isNonZeroBitmap #-}
-isNonZeroBitmap :: Bitmap -> (# (# #) | Bitmap #)
-isNonZeroBitmap 0 = (# (# #) | #)
-isNonZeroBitmap b = (# | b #)
-
-{-# COMPLETE CollisionNode, CompactNode #-}
-
-{-# COMPLETE MapNode #-}
-
--- | A CHAMP-based Hashmap.
---
--- Rather than implementing this as a plain datatype,
--- it is implemented as a typeclass with an associated data family called `HashMap`.
---
--- This convinces GHC that all intermediate constructors are actually not polymorphic at all,
--- and therefore can all be unboxed.
---
--- Conceptually, a `HashMap keys vals k v` you can think of it as:
---
--- @
--- data HashMap (keys :: StrictStorage) (vals :: Storage) k v
---  = EmptyMap 
---  | SingletonMap !k v 
---  | ManyMap {size :: !Word, contents :: (MapNode k v)}
---
--- data MapNode keys vals k v
---    = CollisionNode !(ArrayOf (Strict keys)) !(ArrayOf vals)
---    | CompactNode !Bitmap !Bitmap !(ArrayOf (Strict keys)) !(ArrayOf vals) !(StrictSmallArray (MapNode keys vals k v))
--- @
---
--- with the following tricks:
---
--- - We only store a single 64-bit bitmap (taking up one word) rather than two separate 32-bit bitmaps,
---  and use its lower/higher 32 bits using masking and shifting instead, saving one word per map node.
--- - There is no special `CollisionNode` variant.
---  Instead, we disambiguate using the special bitmap value '0'
---  which can never occur in a valid CompactNode as they are never empty.
--- - As mentioned above, we make sure that GHC unpacks the intermediate array boxes,
---  so we store the `GHC.Exts.SmallArray#` resp `GHC.Exts.ByteArray#` pointers directly.
---  This results in one word saved for the outer map and three more words saved per map node.
--- - We make sure that internal map nodes are stored as `Data.Kind.UnliftedType`
---  inside their array, as we're always strict in the tree-spine of the CHAMP map.
---  This means GHC will skip any thunk-forcing code whenever reading/recursing
--- - We actually don't have `EmptyMap` and `SingletonMap` as separate variants of the outer map type.
---   They are distinguishable by reading the size field. 
---
---      - In the case of `EmptyMap`, only the size is filled in (`0`). We mark it as NOINLINE so all empty maps of a particular type share a single allocation
---      - In the case of `SingletonMap`: 
---
---          - the hash of the single key is stored in place of the `Bitmap`.
---          - the single key is stored in place of the keys array
---          - the single value are stored in place of the values array. Iff the map is lazy in its values, it is wrapped in an extra `Solo` (c.f. `Soloist`).
---
---     Doing this simplifies some code, and allows us to support UNPACKing maps (they cost 5 inline words).
---
--- So in actuality, the memory representation is:
---
--- @
--- data MapNode (keys :: StrictStorage) (vals :: Storage) k v = MapNode 
---   { bitmap :: !Bitmap
---   , keys :: !(ArrayOf (Strict keys) k)
---   , vals :: !(ArrayOf vals v)
---   , children :: !(StrictSmallArray (MapNode keys vals k v))
---   }
---
--- data HashMap (keys :: StrictStorage) (vals :: Storage) k v = HashMap
---   { size :: !Word,
---   , bitmap :: !Bitmap,
---   , keyOrKeys :: !Any,
---   , valOrVals :: !Any,
---   , children :: !(StrictSmallArray (MapNode keys vals k v))
---   }
--- @
-class (Array (ArrayOf (Strict keyStorage)), Array (ArrayOf (valStorage)), Element (ArrayOf (Strict keyStorage)) k, Element (ArrayOf valStorage) v) => MapRepr (keyStorage :: StrictStorage) (valStorage :: Storage) k v where
-  -- | A CHAMP-based HashMap.
-  -- 
-  -- It is recommended to:
-  --
-  -- - Use one of [the concrete types]("Champ.HashMap#concreteTypesComparison") in your code. This will allow GHC to create an optimized implementation.
-  -- - If not possible or youŕe working on highly generic code, use this generic t`HashMap` type, and add @INLINABLE@ or @SPECIALIZE@ pragmas
-  --   to still give GHC the best opportunity to generate efficient code.
-  data HashMap keyStorage valStorage k v
-
-
-  -- | Internal data family representing any map node other than the root of the map.
-  --
-  -- Only used internally, never as part of the external interface.
-  data MapNode keyStorage valStorage k v
-
-  -- Constructs a `MapNode` from an unboxed tuple of its fields
-  packNode :: (# Bitmap, ArrayOf (Strict keyStorage) k, (ArrayOf valStorage) v, StrictSmallArray (MapNode keyStorage valStorage k v) #) -> MapNode keyStorage valStorage k v
-  -- Destructs a `MapNode` into an unboxed tuple of its fields
-  unpackNode :: MapNode keyStorage valStorage k v -> (# Bitmap, ArrayOf (Strict keyStorage) k, (ArrayOf valStorage) v, StrictSmallArray (MapNode keyStorage valStorage k v) #)
-  -- Constructs a `HashMap` with more than one element from its size and root MapNode
-  manyMap :: Word -> MapNode keyStorage valStorage k v -> HashMap keyStorage valStorage k v
-  -- Constructs an empty `HashMap`
-  emptyMap :: HashMap keyStorage valStorage k v
-  -- Constructs a `HashMap` with exactly one key-value pair
-  singletonMap :: Hash -> k -> v -> HashMap keyStorage valStorage k v
-  -- Destructs a HashMap into either an empty hashmap, a singleton hashmap or a many-element hashmap
-  matchMap :: HashMap keyStorage valStorage k v -> (# (# #) | (# Hash, k, v #) | (# Word, MapNode keyStorage valStorage k v #) #)
-
-#define MAP_NODE_NAME(name) MapNode/**/_/**/name
-
-#define MAP_NODE_FIELDS(keystorage, valstorage) \
-     {-# UNPACK #-} !Bitmap \
-     {-# UNPACK #-} !((ArrayOf (Strict (keystorage))) k) \
-     {-# UNPACK #-} !((ArrayOf (valstorage)) v) \
-     {-# UNPACK #-} !(StrictSmallArray (MapNode (keystorage) (valstorage) k v))
-
-#define map_repr_instance(name, keystorage, valstorage, constraints)                                                                                  \
-instance (constraints, Soloist (valstorage)) => MapRepr (keystorage) (valstorage) k v where                                                           \
-{ {-# INLINE unpackNode #-}                                                                                                                           \
-; unpackNode (MAP_NODE_NAME(name) b keys vals children) = (# b, keys, vals, children #)                                                               \
-; {-# INLINE packNode #-}                                                                                                                             \
-; packNode (# b, keys, vals, children #) = (MAP_NODE_NAME(name) b keys vals children)                                                                 \
-; {-# NOINLINE emptyMap #-}                                                                                                                           \
-; emptyMap = Map_/**/name 0 0 (unsafeCoerce (mempty :: ArrayOf (Strict keystorage) k)) (unsafeCoerce (mempty :: ArrayOf (valstorage) v)) mempty       \
-; {-# INLINE singletonMap #-}                                                                                                                         \
-; singletonMap !h !k v = Map_/**/name 1 (unsafeCoerce $ h) (unsafeCoerce k) (unsafeCoerce (solo @(valstorage) v)) mempty                              \
-; {-# INLINE manyMap #-}                                                                                                                              \
-; manyMap mapsize (MAP_NODE_NAME(name) b keys vals children) = Map_/**/name mapsize b (unsafeCoerce keys) (unsafeCoerce vals) children                \
-; {-# INLINE matchMap #-}                                                                                                                             \
-; matchMap = \case {                                                                                                                                  \
-; Map_/**/name 0 _ _ _ _ -> (# (# #) | | #)                                                                                                           \
-; Map_/**/name 1 (unsafeCoerce -> h) (unsafeCoerce -> k) (unsafeCoerce -> soloV) _ -> (#  | (# h, k, unSolo @(valstorage) soloV #) | #)               \
-; Map_/**/name mapsize b keys vals children -> (# | | (# mapsize, MAP_NODE_NAME(name) b (unsafeCoerce keys) (unsafeCoerce vals) children #) #) }      \
-; data MapNode (keystorage) (valstorage) k v = MAP_NODE_NAME(name) MAP_NODE_FIELDS(keystorage, valstorage)                                            \
-; data HashMap (keystorage) (valstorage) k v                                                                                                          \
-  = Map_/**/name !Word !Bitmap !Any !Any !(StrictSmallArray (MapNode (keystorage) (valstorage) k v))                                                  \
-}
-
--- HashMap variants:
--- ** Boxed keys:
-map_repr_instance(Boxed_Lazy, Boxed, Lazy, ())
-map_repr_instance(Boxed_Boxed, Boxed, Strict Boxed, ())
-map_repr_instance(Boxed_Unlifted, Boxed, Strict Unlifted, (PrimUnlifted v))
-map_repr_instance(Boxed_Unboxed, Boxed, Strict Unboxed, (Prim v))
-
--- ** Unboxed keys:
-map_repr_instance(Unboxed_Lazy, Unboxed, Lazy, (Prim k))
-map_repr_instance(Unboxed_Boxed, Unboxed, Strict Boxed, (Prim k))
-map_repr_instance(Unboxed_Unlifted, Unboxed, Strict Unlifted, (Prim k, PrimUnlifted v))
-map_repr_instance(Unboxed_Unboxed, Unboxed, Strict Unboxed, (Prim k, Prim v))
-
--- * Unlifted keys:
-map_repr_instance(Unlifted_Lazy, Unlifted, Lazy, (PrimUnlifted k))
-map_repr_instance(Unlifted_Boxed, Unlifted, Strict Boxed, (PrimUnlifted k))
-map_repr_instance(Unlifted_Unlifted, Unlifted, Strict Unlifted, (PrimUnlifted k, PrimUnlifted v))
-map_repr_instance(Unlifted_Unboxed, Unlifted, Strict Unboxed, (PrimUnlifted k, Prim v))
-
-
--- HashSet internals:
-map_repr_instance(Boxed_Unexistent, Boxed, Unexistent, (IsUnit v))
-map_repr_instance(Unboxed_Unexistent, Unboxed, Unexistent, (Prim k, IsUnit v))
-
 -- | \O(1)\ Return `True` if the map is empty, `False` otherwise
-null :: (MapRepr keys vals k v) => HashMap keys vals k v -> Bool
+null :: MapRepr ks vs k v => HashMap ks vs k v -> Bool
 {-# INLINE null #-}
 null EmptyMap = True
 null _ = False
 
 -- | \O(1)\ Return the number of key-value pairs in this map.
 --
--- Since the map actually keeps track of the size while elements are inserted,
+-- Since the map keeps track of the size while elements are inserted,
 -- this function runs in constant-time.
-size :: (MapRepr keys vals k v) => HashMap keys vals k v -> Int
+size :: MapRepr ks vs k v => HashMap ks vs k v -> Int
 {-# INLINE size #-}
-size EmptyMap = 0
-size (SingletonMap _h _k _v) = 1
-size (ManyMap s _) = fromIntegral s
+size (HashMap s _) = fromIntegral s
 
 -- | \O(1)\ Construct the empty map
 empty :: (MapRepr keys vals k v) => HashMap keys vals k v
 {-# INLINE empty #-}
 empty = EmptyMap
 
--- | \O(1)\ Construct a one-element map
-singleton :: (Hashable k, MapRepr keys vals k v) => k -> v -> HashMap keys vals k v
-{-# INLINE singleton #-}
-singleton !k v = singletonKnownHash (hash k) k v
+singleton :: (Hashable k, MapRepr ks vs k v) => k -> v -> HashMap ks vs k v
+singleton !k v = SingletonMap (hash k) k v
 
-singletonKnownHash :: (MapRepr keys vals k v) => Hash -> k -> v -> HashMap keys vals k v
-singletonKnownHash !h !k v = SingletonMap h k v
+-- singletonKnownHash :: MapRepr ks vs k v => Hash -> k -> v -> HashMap ks vs k v
+-- singletonKnownHash !h !k v = SingletonMap h k v
+
+hash :: (Hashable a) => a -> Hash
+hash x = Hash $ fromIntegral $ Hashable.hash x
+
+{-# INLINE hashToMask #-}
+hashToMask :: Word -> Hash -> Mask
+hashToMask (fromIntegral -> depth) (Hash keyhash) = Mask $ (fromIntegral $ keyhash `unsafeShiftR` depth) .&. BIT_PARTITION_MASK
+
+{-# INLINE maskToBitpos #-}
+maskToBitpos :: Mask -> Bitmap
+maskToBitpos (Mask mask) = 1 `unsafeShiftL` (fromIntegral mask)
+
+{-# INLINE childrenBitmap #-}
+childrenBitmap :: Bitmap -> Bitmap
+childrenBitmap bitmap = bitmap `unsafeShiftR` 32
+
+{-# INLINE leavesBitmap #-}
+leavesBitmap :: (MapRepr keys vals k v) => MapNode keys vals k v -> Bitmap
+leavesBitmap (MapNode bitmap _ _ _) = bitmap .&. (1 `unsafeShiftL` 32 - 1)
+
+{-# INLINE leavesCount #-}
+leavesCount :: (Element (ArrayOf (Strict keys)) k) => (MapRepr keys vals k v) => MapNode keys vals k v -> Int
+leavesCount (CollisionNode keys _) = Contiguous.size keys `div` 2 -- The count of leaves in a CollisionNode
+leavesCount node = popCount $ leavesBitmap node
+
+{-# INLINE childrenCount #-}
+childrenCount :: Bitmap -> Int
+childrenCount bitmap = popCount $ childrenBitmap bitmap
+
+-- | Given a Bitpos, returns the index into the elems array of a node (looking at how many other elems are already in the node's databitmap)
+dataIndex :: Bitmap -> Bitmap -> Int
+{-# INLINE dataIndex #-}
+dataIndex bitmap bitpos =
+  popCount $ bitmap .&. (bitpos - 1)
+
+-- | Given a Bitpos, returns the index into the elems array of a node (looking at how many other elems are already in the node's nodebitmap)
+childrenIndex :: Bitmap -> Bitmap -> Int
+{-# INLINE childrenIndex #-}
+childrenIndex bitmap bitpos =
+  popCount $ (childrenBitmap bitmap) .&. (bitpos - 1)
+
+nextShift :: (Num a) => a -> a
+nextShift s = s + BIT_PARTITION_SIZE
 
 data Location = Inline | InChild | Nowhere
 
-bitposLocation :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> Location
+bitposLocation :: Bitmap -> Bitmap -> Location
 {-# INLINE bitposLocation #-}
-bitposLocation node@(MapNode bitmap _ _ _) bitpos
+bitposLocation bitmap bitpos
   | bitmap .&. bitpos /= 0 = Inline
-  | (childrenBitmap node) .&. bitpos /= 0 = InChild
+  | (childrenBitmap bitmap) .&. bitpos /= 0 = InChild
   | otherwise = Nowhere
 
--- \(O(n \log32 n)\) Construct a map with the supplied key-value mappings.
--- 
--- If the list contains duplicate keys, later mappings take precedence.
-fromList :: (Hashable k, MapRepr keys vals k v) => [(k, v)] -> HashMap keys vals k v
-{-# INLINE fromList #-}
-fromList = Foldable.foldl' (\m (k, v) -> unsafeInsert k v m) empty
-
--- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
--- the provided function @f@ to merge duplicate entries with
--- @(f newVal oldVal)@.
-fromListWith :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
-{-# INLINE fromListWith #-}
-fromListWith f = List.foldl' (\m (k, v) -> unsafeInsertWith f k v m) empty
-
--- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
--- the provided function @f@ to merge duplicate entries with
--- @(f key newVal oldVal)@.
-fromListWithKey :: (Eq k, Hashable k, MapRepr keys vals k v) => (k -> v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
-{-# INLINE fromListWithKey #-}
-fromListWithKey f = List.foldl' (\m (k, v) -> unsafeInsertWithKey f k v m) empty
-
--- | \(O(n)\) Return a list of this map's elements (key-value pairs).
---
--- The resulting list is produced lazily and may participate in list fusion.
--- The order of its elements is unspecified.
-toList :: (MapRepr keys vals k v) => HashMap keys vals k v -> [(k, v)]
-{-# INLINE toList #-}
-toList hashmap = Exts.build (\fusedCons fusedNil -> foldrWithKey (\k v xs -> (k, v) `fusedCons` xs) fusedNil hashmap)
-
--- | \(O(\log32 n)\) Adjust the value tied to a given key in this map only
--- if it is present. Otherwise, leave the map alone.
---
--- The current implementation is very simple
--- but is not super performant as it will traverse the map twice.
-adjust :: (Hashable k, MapRepr keys vals k v) => (v -> v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
-adjust f k m = 
-  lookupKVKnownHash# absent present h k m
-  where
-    h = hash k
-    absent (# #) = m
-    present k' v = 
-      let v' = f v 
-      in insert' Safe h k' v' m 
-
--- | \(O(\log32 n)\)  The expression @('alter' f k map)@ alters the value @x@ at @k@, or
--- absence thereof.
---
--- 'alter' can be used to insert, delete, or update a value in a map.
---
--- If the function returns Nothing, the key is removed from the map.
--- If the function returns Just v', the key is inserted or replaced with the new value.
---
--- The current implementation is very simple,
--- but is not super performant.
-alter :: (Hashable k, MapRepr keys vals k v) => (Maybe v -> Maybe v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
-{-# INLINABLE alter #-}
-alter f k m = 
-  let h = hash k
-  in
-  case lookupKVKnownHash h k m of
-  Nothing -> 
-    case f Nothing of
-      Nothing -> m
-      Just v -> insert' Safe h k v m
-  Just (k', v) -> 
-    case f (Just v) of
-      Nothing -> delete' Safe h k' m
-      Just v' -> if ptrEq v v' then m else insert' Safe h k' v' m
-
--- | \(O(\log32 n)\)  The expression @('update' f k map)@ updates the value @x@ at @k@
--- (if it is in the map). If @(f x)@ is 'Nothing', the element is deleted.
--- If it is @('Just' y)@, the key @k@ is bound to the new value @y@.
-update :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> Maybe v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
-{-# INLINABLE update #-}
-update f = alter (>>= f)
-
--- | \(O(\log32 n)\)  The expression @('alterF' f k map)@ alters the value @x@ at
--- @k@, or absence thereof.
---
---  'alterF' can be used to insert, delete, or update a value in a map.
---
--- 'alterF' is a flipped version of the 'at' combinator from
--- <https://hackage.haskell.org/package/lens/docs/Control-Lens-At.html#v:at Control.Lens.At>.
---
---
--- The current implementation does not (yet) have a set of rewrite rules in place
--- that optimize particular common kinds of `f`. 
-alterF :: (MapRepr keys vals a1 a2, Hashable a1, Functor f) => (Maybe a2 -> f (Maybe a2)) -> a1 -> HashMap keys vals a1 a2 -> f (HashMap keys vals a1 a2)
-{-# INLINE alterF #-}
-alterF f = \ !k !m ->
-  let
-    !h = hash k
-  in
-    case lookupKVKnownHash h k m of
-      Nothing -> do
-        mv <- (f Nothing)
-        pure $ case mv of
-          Nothing -> m
-          Just v -> (insert' Safe h k v m)
-      Just (k', v) -> do 
-        mv <- (f (Just v))
-        pure $ case mv of
-          Nothing -> delete' Safe h k' m
-          Just v' -> insert' Safe h k' v' m
-
--- | \(O(n \log32 n)\).
--- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
---
--- The size of the result may be smaller if @f@ maps two or more distinct
--- keys to the same new key. In this case there is no guarantee which of the
--- associated values is chosen for the conflicting key.
---
--- >>> Champ.HashMap.mapKeys (+ 1) (Champ.HashMap.fromList [(5,"a"), (3,"b")] :: HashMapUUl Int ShortText)
--- Champ.HashMap.fromList [(4,"b"),(6,"a")]
--- >>> Champ.HashMap.mapKeys (\ _ -> 1.0) (Champ.HashMap.fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")] :: HashMapUUl Int ShortText)
--- Champ.HashMap.fromList [(1.0,"c")]
--- >>> Champ.HashMap.mapKeys (\ _ -> 3 :: Int) (Champ.HashMap.fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")] :: HashMapUUl Int ShortText)
--- Champ.HashMap.fromList [(3,"c")]
-mapKeys :: (Eq k2, Hashable k2, MapRepr keys vals k1 v, MapRepr keys vals k2 v) => (k1 -> k2) -> HashMap keys vals k1 v -> HashMap keys vals k2 v
-{-# INLINE mapKeys #-}
-mapKeys = mapKeys'
-
-mapKeys' :: (Eq k2, Hashable k2, MapRepr keys vals k1 v, MapRepr keys2 vals k2 v) => (k1 -> k2) -> HashMap keys vals k1 v -> HashMap keys2 vals k2 v
-{-# INLINE mapKeys' #-}
-mapKeys' f = Champ.Internal.fromList . Champ.Internal.foldrWithKey (\k x xs -> (f k, x) : xs) []
-
+myThing :: HashMapUU Int Int
+myThing = singleton 42 69
 
 -- | \(O(\log32 n)\) Associate the specified value with the specified
 -- key in this map.  If this map previously contained a mapping for
@@ -546,66 +392,49 @@ unsafeInsert k = insert' Unsafe (hash k) k
 
 insert' :: (Hashable k, MapRepr keys vals k v) => Safety -> Hash -> k -> v -> HashMap keys vals k v -> HashMap keys vals k v
 {-# INLINE insert' #-}
-insert' safety h !k v !m = case matchMap m of
-  (# (# #) | | #) -> singleton k v
-  (# | (# h', k', v' #) | #) ->
-    if h == h' && k == k'
-      then singletonKnownHash h k' v
-      else
-          Contiguous.empty
-            & MapNode (maskToBitpos (hashToMask 0 (hash k'))) (Array.singleton safety k') (Array.singleton safety v')
-            & \node -> insertInNode safety h k v 0 node 
-              (\size node' -> ManyMap (1 + Exts.W# size) node')
-  (# | | (# size, node0 #) #) ->
-    insertInNode safety h k v 0 node0 (\didIGrow node' -> ManyMap (size + Exts.W# didIGrow) node')
+insert' safety h !k v !m = case m of
+    EmptyMap -> singleton k v
+    SingletonMap h' k' v' ->
+        if h == h' && k == k'
+        then SingletonMap h k' v
+        else
+                CompactNode (maskToBitpos (hashToMask 0 (hash k'))) (Array.singleton safety k') (Array.singleton safety v') (Contiguous.empty)
+                & \node -> insertInNode safety h k v 0 node
+                (\s node' -> ManyMap (1 + Exts.W# s) node')
+    ManyMap s node0 ->
+        insertInNode safety h k v 0 node0 (\didIGrow node' -> ManyMap (s + Exts.W# didIGrow) node')
 
-insertInNode :: (MapRepr keys vals k v, Hashable k) =>
-                Safety
-                -> Hash
-                -> k
-                -> v
-                -> Word
-                -> MapNode keys vals k v
-                -> (Exts.Word# -> MapNode keys vals k v -> r)
-                -> r
 {-# INLINEABLE insertInNode #-}
+insertInNode :: (Hashable k, MapRepr ks vs k v) => Safety -> Hash -> k -> v -> Word -> MapNode ks vs k v -> (Exts.Word# -> MapNode ks vs k v -> r) -> r
 insertInNode safety !h !k v !shift node cont = case node of
-  !node@(CollisionNode _ _) -> cont 1## (insertCollision safety k v node)
-  !node@(CompactNode !bitmap !keys !vals !children) ->
+  !(CollisionNode ks vs) -> cont 1## (insertCollision safety k v ks vs)
+  !(CompactNode !bitmap !keys !vals !children) ->
     let !bitpos = maskToBitpos $ hashToMask shift h
-    in case bitposLocation node bitpos of
+    in case bitposLocation bitmap bitpos of
         Inline ->
           -- exists inline; potentially turn inline to subnode with two keys
-          insertMergeWithInline safety bitpos k v h shift node cont
+          insertMergeWithInline safety bitpos k v h shift bitmap keys vals children cont
         InChild ->
           -- Exists in child, insert in there and make sure this node contains the updated child
-          let child = indexChild node bitpos
+          let child = indexChild bitmap children bitpos
           in insertInNode safety h k v (nextShift shift) child 
           (\didIGrow child' -> 
             child'
-            & Array.replaceAt safety children (childrenIndex node bitpos)
+            & Array.replaceAt safety children (childrenIndex bitmap bitpos)
             & CompactNode bitmap keys vals
             & cont didIGrow
           )
         Nowhere ->
           -- Doesn't exist yet, we can insert inline
-          cont 1## (insertNewInline safety bitpos k v node)
-
--- {-# SPECIALIZE insert :: Hashable k => k -> v -> HashMapBL k v -> HashMapBL k v #-}
--- {-# SPECIALIZE insert :: Hashable k => k -> v -> HashMapBB k v -> HashMapBB k v #-}
--- {-# SPECIALIZE insert :: (Hashable k, Prim v) => k -> v -> HashMapBU k v -> HashMapBU k v #-}
--- {-# SPECIALIZE insert :: (Hashable k, Prim k) => k -> v -> HashMapUL k v -> HashMapUL k v #-}
--- {-# SPECIALIZE insert :: (Hashable k, Prim k) => k -> v -> HashMapUB k v -> HashMapUB k v #-}
--- {-# SPECIALIZE insert :: (Hashable k, Prim k, Prim v) => k -> v -> HashMapUU k v -> HashMapUU k v #-}
--- {-# SPECIALIZE insert :: Int -> Int -> HashMapUU Int Int -> HashMapUU Int Int #-}
+          cont 1## (insertNewInline safety bitpos k v bitmap keys vals children)
 
 -- Collisions are appended at the end
 -- Note that we cannot insert them in sorted order
 -- (which would theoretically allow a binary search on lookup)
 -- because we don't have an `Ord` instance.
 {-# INLINE insertCollision #-}
-insertCollision :: (MapRepr keys vals k v, Eq k) => Safety -> k -> v -> MapNode keys vals k v -> MapNode keys vals k v
-insertCollision safety k v (MapNode _ keys vals _) =
+insertCollision :: (MapRepr ks vs k v, Eq k) => Safety -> k -> v -> ArrayOf (Strict ks) k -> ArrayOf vs v -> MapNode ks vs k v
+insertCollision safety k v keys vals =
   keys
   & Contiguous.findIndex (== k)
   & replaceOrAppend
@@ -617,23 +446,23 @@ insertCollision safety k v (MapNode _ keys vals _) =
       in CollisionNode (Array.insertAt safety keys idx k) (Array.insertAt safety vals idx v)
 
 {-# INLINE insertNewInline #-}
-insertNewInline :: (MapRepr keys vals k v) => Safety -> Bitmap -> k -> v -> MapNode keys vals k v -> MapNode keys vals k v
-insertNewInline safety bitpos k v node@(MapNode bitmap keys vals children) =
+insertNewInline :: (MapRepr ks vs k v) => Safety -> Bitmap -> k -> v -> Bitmap -> ArrayOf (Strict ks) k -> ArrayOf vs v -> StrictSmallArray (MapNode ks vs k v) -> MapNode ks vs k v
+insertNewInline safety bitpos k v bitmap keys vals children =
   let bitmap' = bitmap .|. bitpos
-      idx = dataIndex node bitpos
+      idx = dataIndex bitmap bitpos
       keys' = Array.insertAt safety keys idx k
       vals' = Array.insertAt safety vals idx v
-   in MapNode bitmap' keys' vals' children
+   in CompactNode bitmap' keys' vals' children
 
 {-# INLINE insertMergeWithInline #-}
-insertMergeWithInline :: (Hashable k, MapRepr keys vals k v) => Safety -> Bitmap -> k -> v -> Hash -> Word -> MapNode keys vals k v -> (Exts.Word# -> MapNode keys vals k v -> r) -> r
-insertMergeWithInline safety bitpos k v h shift node@(MapNode bitmap keys vals children) cont =
-  let idx = dataIndex node bitpos
-      existingKey = indexKey node bitpos
-      (# existingVal #) = indexVal# node bitpos
+insertMergeWithInline :: (Hashable k, MapRepr ks vs k v) => Safety -> Bitmap -> k -> v -> Hash -> Word -> Bitmap -> ArrayOf (Strict ks) k -> ArrayOf vs v -> StrictSmallArray (MapNode ks vs k v) -> (Exts.Word# -> MapNode ks vs k v -> r) -> r
+insertMergeWithInline safety bitpos k v h shift bitmap keys vals children cont =
+  let idx = dataIndex bitmap bitpos
+      existingKey = indexKey bitmap keys bitpos
+      (# existingVal #) = indexVal# bitmap vals bitpos
    in if existingKey == k then cont 1## (CompactNode bitmap keys (Array.replaceAt safety vals idx v) children )
       else
-          let newIdx = childrenIndex node bitpos
+          let newIdx = childrenIndex bitmap bitpos
               -- SAFETY: The forcing of `child`/`pairNode` here is extremely important
               -- if we're in `Unsafe` mode about to delete `existingVal` from the values array;
               -- then when we are too lazy in the _fetching_ of `existingVal`,
@@ -642,7 +471,7 @@ insertMergeWithInline safety bitpos k v h shift node@(MapNode bitmap keys vals c
               keys' = Array.deleteAt safety keys idx
               vals' = Array.deleteAt safety vals idx
               !children' = Array.insertAt safety children newIdx child
-              bitmap' = bitmap .^. bitpos .|. (bitpos `unsafeShiftL` HASH_CODE_LENGTH)
+              bitmap' = bitmap .^. bitpos .|. (bitpos `unsafeShiftL` (1 `unsafeShiftL` 5))
             in cont 1## (CompactNode bitmap' keys' vals' children')
 
 {-# INLINE pairNode #-}
@@ -698,6 +527,127 @@ mergeCompactInline safety k1 v1 h1 k2 v2 h2 shift =
       vals = Array.doubletonBranchless safety c v1 v2
    in CompactNode bitmap keys vals Contiguous.empty
 
+
+-- | Looks up a key in a MapNode. Should only be called if the node is a CompactNode
+indexKey :: (Array (ArrayOf (Strict keys)), Element (ArrayOf (Strict keys)) k) => Bitmap -> ArrayOf (Strict keys) k -> Bitmap -> k
+{-# INLINE indexKey #-}
+indexKey bitmap keys bitpos =
+    Contiguous.index keys (dataIndex bitmap bitpos)
+
+-- | Looks up a value in a MapNode. Should only be called if the node is a CompactNode
+indexVal# :: ((Array (ArrayOf vs)), Element (ArrayOf vs) v) => Bitmap -> ArrayOf vs v -> Bitmap -> (# v #)
+{-# INLINE indexVal# #-}
+indexVal# bitmap vals bitpos =
+    Contiguous.index# vals (dataIndex bitmap bitpos)
+
+-- | Looks up a chidl in a MapNode. Should only be called if the node is a CompactNode
+indexChild :: Bitmap -> StrictSmallArray (MapNode ks vs k v) -> Bitmap -> MapNode ks vs k v
+{-# INLINE indexChild #-}
+indexChild bitmap children bitpos =
+    Contiguous.index children (childrenIndex bitmap bitpos)
+
+
+-- | \O(log n)\ Return `True` if the specified key is present in the map, `False` otherwise.
+member :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Bool
+{-# INLINE member #-}
+member k m = case lookupKV# k m of 
+  (# (# #) | #) -> True
+  _ -> False
+
+-- | Look up the value for a given key.
+--
+-- Returns `Nothing` if the key does not exist in the map.
+lookup :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Maybe v
+{-# INLINE lookup #-}
+lookup k m = case lookupKV# k m of
+  (# (# #) | #) -> Nothing
+  (# | (# _k, v #) #) -> Just v
+
+-- | Version of lookup that also returns the found key.
+--
+-- This is only useful if the 'memory identity' of the key is important.
+-- It usually isn't, but sometimes it is: For example, some equality checks can short-cirquit using pointer-equality
+-- and by fetching a key that is known to be the same pointer, you can speed up equality checks in the future,
+-- as well as deduplicate the memory you're holding onto.
+lookupKV :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Maybe (k, v)
+{-# INLINE lookupKV #-}
+lookupKV !k = lookupKVKnownHash (hash k) k
+
+lookupKV# :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> (# (# #) | (# k, v #) #)
+{-# INLINE lookupKV# #-}
+lookupKV# !k = lookupKVKnownHash# absent present (hash k) k
+  where
+    absent :: (# #) -> (# (# #) | (# k, v #) #)
+    absent (# #) = (# (# #) | #)
+    present :: k -> v -> (# (# #) | (# k, v #) #)
+    present k' v = (# | (# k', v #) #)
+
+lookupKVKnownHash :: (MapRepr keys vals a b, Hashable a) => Hash -> a -> HashMap keys vals a b -> Maybe (a, b)
+{-# INLINE lookupKVKnownHash #-}
+lookupKVKnownHash = lookupKVKnownHash# absent present
+  where
+    absent (# #) = Nothing
+    present k v = Just (k, v)
+
+lookupKVKnownHash# 
+  :: forall rep (r :: Exts.TYPE rep) keys vals k v.
+  (MapRepr keys vals k v, Eq k, Hashable k)
+  => ((# #) -> r) -- Absent continuation
+  -> (k -> v -> r) -- Present continuation
+  -> Hash -> k -> HashMap keys vals k v -> r
+{-# INLINE lookupKVKnownHash# #-}
+lookupKVKnownHash# absent present h !k m = case m of
+  HashMap 0 (MapNode _ _ _ _) -> absent (# #)
+  HashMap 1 (MapNode singleHash singleKey singleVal _) ->
+        let 
+            h' = coerce singleHash
+            k' = unBox singleKey
+            v' = unSolo @vals (unBox singleVal)
+        in
+            if h == h' && k == k' then present k v' else absent (# #)
+  HashMap _ (MapNode bitmap (unBox @(ArrayOf (Strict keys) k) -> keys) (unBox @(ArrayOf vals v) -> vals) children) ->
+--   EmptyMap -> absent (# #)
+--   SingletonMap h' k' v' -> if h == h' && k == k' then present k' v' else absent (# #)
+--   ManyMap _ (CompactNode bitmap keys vals children) ->
+    -- NOTE: Manually inlining the first iteration of lookup'
+    -- (which will _never_ be in a collision node)
+    -- results in a noticeable speedup for maps that have at most 32 elements.
+    let !bitpos = maskToBitpos $ hashToMask 0 h
+    in case bitposLocation bitmap bitpos of
+        Nowhere -> absent (# #)
+        Inline ->
+            let k' = indexKey bitmap keys bitpos
+                (# v #) = indexVal# bitmap vals bitpos
+            in if k == k' then present k' v else absent (# #)
+        InChild -> lookup' (nextShift 0) (indexChild bitmap children bitpos)
+            where
+                {-# INLINEABLE lookup' #-}
+                lookup' !_s !(CollisionNode keys vals) =
+                  case findCollisionIndex# k keys of
+                    (# (# #) | #) -> absent (# #)
+                    (# | idx #) -> present (Contiguous.index keys idx) (Contiguous.index vals idx)
+                lookup' !s !(CompactNode bitmap' keys' vals' children') =
+                    let !bitpos = maskToBitpos $ hashToMask s h
+                    in case bitposLocation bitmap' bitpos of
+                            Nowhere -> absent (# #)
+                            Inline ->
+                                let k' = indexKey bitmap keys' bitpos
+                                    (# v #) = indexVal# bitmap vals' bitpos
+                                in if k == k' then present k' v else absent (# #)
+                            InChild -> lookup' (nextShift s) (indexChild bitmap children' bitpos)
+  -- ManyMap _ _ -> error "unreachable: A ManyMap can only contain a CompactNode at the root."
+
+-- mylookup :: Int -> HashMapUU Int Int -> Maybe Int
+-- mylookup = lookup
+
+findCollisionIndex# :: (Eq a, Array arr, Element arr a) => a -> arr a -> (# (# #) | Int #)
+{-# INLINE findCollisionIndex# #-}
+findCollisionIndex# k keys = Array.findIndex# (\existingKey -> existingKey `ptrEq` k || existingKey == k) keys
+
+
+myLookup :: Int -> HashMapUU Int Int -> Maybe Int
+myLookup = lookup
+
 -- | \(O(\log32 n)\) Associate the value with the key in this map.  If
 -- this map previously contained a mapping for the key, the old value
 -- is replaced by the result of applying the given function to the new
@@ -748,15 +698,15 @@ unsafeDelete k = delete' Unsafe (hash k) k
 
 delete' :: (Hashable k, MapRepr keys vals k v) => Safety -> Hash -> k -> HashMap keys vals k v -> HashMap keys vals k v
 {-# INLINE delete' #-}
-delete' safety h !k !m = case matchMap m of
-  (# (# #) | | #) -> EmptyMap
-  (# | (# h', k', v #) | #) 
+delete' safety h !k !m = case m of
+  EmptyMap -> EmptyMap
+  SingletonMap h' k' v
     | k == k' -> EmptyMap
     | otherwise -> SingletonMap h' k' v
-  (# | | (# size, node0 #) #) ->
+  ManyMap s node0 ->
     case deleteFromNode safety h k 0 node0 of
       (# (# k', v #) | #) -> singleton k' v
-      (# | (# didIShrink, node #) #) -> ManyMap (size - Exts.W# didIShrink) node
+      (# | (# didIShrink, node #) #) -> ManyMap (s - Exts.W# didIShrink) node
 
 deleteFromNode :: (MapRepr keyStorage valStorage a1 a2, Eq a1) =>
                         Safety
@@ -789,13 +739,13 @@ deleteFromNode safety !h !k !shift = \case
         (# | (# 1##, node' #) #)
   node@(CompactNode !bitmap !keys !vals !children) ->
     let !bitpos = maskToBitpos (hashToMask shift h)
-    in case bitposLocation node bitpos of
+    in case bitposLocation bitmap bitpos of
       Nowhere ->
         -- Nothing to delete, return self
         (# | (# 0##, node #) #)
       Inline ->
         -- Delete locally
-        let existingKey = indexKey node bitpos
+        let existingKey = indexKey bitmap keys bitpos
         in if 
              | existingKey /= k -> 
               -- Deleting something with the same hash
@@ -804,7 +754,7 @@ deleteFromNode safety !h !k !shift = \case
              | existingKey == k && (Contiguous.size keys == 2) ->
               -- Collapse this array of two elements into a singleton node;
               -- and bubble it up to be merged inline one layer up
-              case (dataIndex node bitpos) of
+              case (dataIndex bitmap bitpos) of
                 0 ->
                   let (# existingVal #) = Contiguous.index# vals 1
                       existingKey = Contiguous.index keys 1
@@ -815,7 +765,7 @@ deleteFromNode safety !h !k !shift = \case
                   in (# (# existingKey, existingVal #) | #)
                 _ -> error "Unreachable"
              | otherwise ->
-              let idx = dataIndex node bitpos
+              let idx = dataIndex bitmap bitpos
                   keys' = Array.deleteAt safety keys idx
                   vals' = Array.deleteAt safety vals idx
                   bitmap' = bitmap .^. bitpos
@@ -823,146 +773,21 @@ deleteFromNode safety !h !k !shift = \case
                 (# | (# 1##, CompactNode bitmap' keys' vals' children #) #)
       InChild ->
         -- Recurse
-        let child = indexChild node bitpos
-            childIndex = childrenIndex node bitpos
-            bitmap' = bitmap .^. (bitpos `unsafeShiftL` HASH_CODE_LENGTH)
+        let child = indexChild bitmap children bitpos
+            childIndex = childrenIndex bitmap bitpos
+            bitmap' = bitmap .^. (bitpos `unsafeShiftL` (1 `unsafeShiftL` 5))
         in
           case deleteFromNode safety h k (nextShift shift) child of
             (# (# k', v' #) | #) ->
               -- Child became too small, replace with inline
               let 
-                arr = Array.deleteAt safety children childIndex
-                node = CompactNode bitmap' keys vals arr
-                node' = insertNewInline safety bitpos k' v' node
+                children' = Array.deleteAt safety children childIndex
+                node' = insertNewInline safety bitpos k' v' bitmap' keys vals children'
               in
                 (# | (# 1##, node' #) #)
             (# | (# didIGrow, child' #) #) ->
               let node' = CompactNode bitmap' keys vals (Array.replaceAt safety children childIndex child')
               in (# | (# didIGrow, node' #) #)
-
--- | Look up the value for a given key.
---
--- Returns `Nothing` if the key does not exist in the map.
-lookup :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Maybe v
-{-# INLINE lookup #-}
-lookup k m = case lookupKV# k m of
-  (# (# #) | #) -> Nothing
-  (# | (# _k, v #) #) -> Just v
-
--- | Version of lookup that also returns the found key.
---
--- This is only useful if the 'memory identity' of the key is important.
--- It usually isn't, but sometimes it is: For example, some equality checks can short-cirquit using pointer-equality
--- and by fetching a key that is known to be the same pointer, you can speed up equality checks in the future,
--- as well as deduplicate the memory you're holding onto.
-lookupKV :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Maybe (k, v)
-{-# INLINE lookupKV #-}
-lookupKV !k = lookupKVKnownHash (hash k) k
-
-lookupKV# :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> (# (# #) | (# k, v #) #)
-{-# INLINE lookupKV# #-}
-lookupKV# !k = lookupKVKnownHash# absent present (hash k) k
-  where
-    absent :: (# #) -> (# (# #) | (# k, v #) #)
-    absent (# #) = (# (# #) | #)
-    present :: k -> v -> (# (# #) | (# k, v #) #)
-    present k v = (# | (# k, v #) #)
-
-lookupKVKnownHash :: (MapRepr keys vals a b, Hashable a) => Hash -> a -> HashMap keys vals a b -> Maybe (a, b)
-{-# INLINE lookupKVKnownHash #-}
-lookupKVKnownHash = lookupKVKnownHash# absent present
-  where
-    absent (# #) = Nothing
-    present k v = Just (k, v)
-
-lookupKVKnownHash# 
-  :: forall rep (r :: Exts.TYPE rep) keys vals k v.
-  (MapRepr keys vals k v, Eq k, Hashable k)
-  => ((# #) -> r) -- Absent continuation
-  -> (k -> v -> r) -- Present continuation
-  -> Hash -> k -> HashMap keys vals k v -> r
-{-# INLINE lookupKVKnownHash# #-}
-lookupKVKnownHash# absent present h !k m = case matchMap m of
-  (# (# #) | | #) -> absent (# #)
-  (# | (# h', k', v #) | #) -> if h == h' && k == k' then present k' v else absent (# #)
-  (# | | (# _size, node0 #) #) ->
-    -- NOTE: Manually inlining the first iteration of lookup'
-    -- (which will _never_ be in a collision node)
-    -- results in a noticeable speedup for maps that have at most 32 elements.
-    let !bitpos = maskToBitpos $ hashToMask 0 h
-    in case bitposLocation node0 bitpos of
-        Nowhere -> absent (# #)
-        Inline ->
-            let k' = indexKey node0 bitpos
-                (# v #) = indexVal# node0 bitpos
-            in if k == k' then present k' v else absent (# #)
-        InChild -> lookup' (nextShift 0) (indexChild node0 bitpos)
-            where
-                {-# INLINEABLE lookup' #-}
-                lookup' !_s !(CollisionNode keys vals) =
-                  case findCollisionIndex# k keys of
-                    (# (# #) | #) -> absent (# #)
-                    (# | idx #) -> present (Contiguous.index keys idx) (Contiguous.index vals idx)
-                lookup' !s !node@(CompactNode _bitmap _keys _vals _children) =
-                    let !bitpos = maskToBitpos $ hashToMask s h
-                    in case bitposLocation node bitpos of
-                            Nowhere -> absent (# #)
-                            Inline ->
-                                let k' = indexKey node bitpos
-                                    (# v #) = indexVal# node bitpos
-                                in if k == k' then present k' v else absent (# #)
-                            InChild -> lookup' (nextShift s) (indexChild node bitpos)
-
--- mylookup :: Int -> HashMapUU Int Int -> Maybe Int
--- mylookup = lookup
-
-findCollisionIndex# :: (Eq a, Array arr, Element arr a) => a -> arr a -> (# (# #) | Int #)
-{-# INLINE findCollisionIndex# #-}
-findCollisionIndex# k keys = Array.findIndex# (\existingKey -> existingKey `ptrEq` k || existingKey == k) keys
-
--- indexKey :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> k
--- {-# INLINE indexKey #-}
--- indexKey (CollisionNode _keys _vals) _ = error "Should only be called on CompactNodes"
--- indexKey node@(CompactNode _bitmap keys _vals _children) bitpos =
---     Contiguous.index keys (dataIndex node bitpos)
-
--- indexVal# :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> (# v #)
--- {-# INLINE indexVal# #-}
--- indexVal# (CollisionNode _keys _vals) _ = error "Should only be called on CompactNodes"
--- indexVal# node@(CompactNode _bitmap _keys vals _children) bitpos =
---     Contiguous.index# vals (dataIndex node bitpos)
-
--- indexChild :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> MapNode keys vals k v
--- {-# INLINE indexChild #-}
--- indexChild (CollisionNode _keys _vals) _ = error "Should only be called on CompactNodes"
--- indexChild node@(CompactNode _bitmap _keys _vals children) bitpos =
---     Contiguous.index children (childrenIndex node bitpos)
-
--- | Looks up a key in a MapNode. Should only be called if the node is a CompactNode
-indexKey :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> k
-{-# INLINE indexKey #-}
-indexKey node@(MapNode _bitmap keys _vals _children) bitpos =
-    Contiguous.index keys (dataIndex node bitpos)
-
--- | Looks up a value in a MapNode. Should only be called if the node is a CompactNode
-indexVal# :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> (# v #)
-{-# INLINE indexVal# #-}
-indexVal# node@(MapNode _bitmap _keys vals _children) bitpos =
-    Contiguous.index# vals (dataIndex node bitpos)
-
--- | Looks up a chidl in a MapNode. Should only be called if the node is a CompactNode
-indexChild :: MapRepr keys vals k v => MapNode keys vals k v -> Bitmap -> MapNode keys vals k v
-{-# INLINE indexChild #-}
-indexChild node@(MapNode _bitmap _keys _vals children) bitpos =
-    Contiguous.index children (childrenIndex node bitpos)
-
-
--- | \O(log n)\ Return `True` if the specified key is present in the map, `False` otherwise.
-member :: (MapRepr keys vals k v, Eq k, Hashable k) => k -> HashMap keys vals k v -> Bool
-{-# INLINE member #-}
-member k m = case lookupKV# k m of 
-  (# (# #) | #) -> True
-  _ -> False
 
 instance (MapRepr keys vals k v, Eq v, Eq k) => Eq (HashMap keys vals k v) where
   {-# INLINE (==) #-}
@@ -989,8 +814,6 @@ instance (MapRepr keys vals k v, Eq v, Eq k) => Eq (MapNode keys vals k v) where
       && (c1 `Contiguous.same` c2 || c1 `Contiguous.equals` c2) -- Here we recurse
   _ == _ = False
 
--- myeq :: HashMapUU Int Int -> HashMapUU Int Int -> Bool
--- myeq a b = a == b
 
 instance (Hashable k, Eq k, MapRepr keys vals k v) => IsList (HashMap keys vals k v) where
   type Item (HashMap keys vals k v) = (k, v)
@@ -1008,7 +831,7 @@ instance (NFData v, NFData k, (MapRepr keys vals k v), NFData (MapNode keys vals
 instance {-# OVERLAPPABLE #-} (NFData k, NFData v, MapRepr keys vals k v) => NFData (MapNode keys vals k v) where
   {-# INLINE rnf #-}
   rnf (CollisionNode keys vals) = Contiguous.rnf keys `seq` Contiguous.rnf vals
-  rnf (MapNode bitmap keys vals children) =
+  rnf (CompactNode bitmap keys vals children) =
     rnf bitmap `seq` Contiguous.rnf keys `seq` Contiguous.rnf vals `seq` Contiguous.rnf children
 
 instance {-# OVERLAPS #-} (NFData k, NFData v) => NFData (MapNode Unboxed (Strict Unboxed) k v) where
@@ -1076,494 +899,167 @@ map' !f = \case
         in
           CompactNode bitmap keys vals' children'
 
-instance Traversable (HashMapBL k) where
-  traverse = Champ.Internal.traverse
 
-instance Traversable (HashMapBB k) where
-  traverse = Champ.Internal.traverse
+-- @'mapKeys' f s@ is the map obtained by applying @f@ to each key of @s@.
+--
+-- The size of the result may be smaller if @f@ maps two or more distinct
+-- keys to the same new key. In this case there is no guarantee which of the
+-- associated values is chosen for the conflicting key.
+--
+-- >>> Champ.HashMap.mapKeys (+ 1) (Champ.HashMap.fromList [(5,"a"), (3,"b")] :: HashMapUUl Int ShortText)
+-- Champ.HashMap.fromList [(4,"b"),(6,"a")]
+-- >>> Champ.HashMap.mapKeys (\ _ -> 1.0) (Champ.HashMap.fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")] :: HashMapUUl Int ShortText)
+-- Champ.HashMap.fromList [(1.0,"c")]
+-- >>> Champ.HashMap.mapKeys (\ _ -> 3 :: Int) (Champ.HashMap.fromList [(1,"b"), (2,"a"), (3,"d"), (4,"c")] :: HashMapUUl Int ShortText)
+-- Champ.HashMap.fromList [(3,"c")]
+mapKeys :: (Eq k2, Hashable k2, MapRepr keys vals k1 v, MapRepr keys vals k2 v) => (k1 -> k2) -> HashMap keys vals k1 v -> HashMap keys vals k2 v
+{-# INLINE mapKeys #-}
+mapKeys = mapKeys'
 
-traverse :: (Applicative f, MapRepr keys vals k a, MapRepr keys vals k b) => (a -> f b) -> HashMap keys vals k a -> f (HashMap keys vals k b)
-{-# INLINE traverse #-}
-traverse f = traverseWithKey (const f)
+mapKeys' :: (Eq k2, Hashable k2, MapRepr keys vals k1 v, MapRepr keys2 vals k2 v) => (k1 -> k2) -> HashMap keys vals k1 v -> HashMap keys2 vals k2 v
+{-# INLINE mapKeys' #-}
+mapKeys' f = Champ.Internal.fromList . Champ.Internal.foldrWithKey (\k x xs -> (f k, x) : xs) []
 
-traverse' :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (a -> f b) -> HashMap keys as k a -> f (HashMap keys bs k b)
-{-# INLINE traverse' #-}
-traverse' f = traverseWithKey' (const f)
 
-traverseWithKey :: (Applicative f, MapRepr keys vals k a, MapRepr keys vals k b) => (k -> a -> f b) -> HashMap keys vals k a -> f (HashMap keys vals k b)
-{-# INLINE traverseWithKey #-}
-traverseWithKey = traverseWithKey'
+-- \(O(n \log32 n)\) Construct a map with the supplied key-value mappings.
+-- 
+-- If the list contains duplicate keys, later mappings take precedence.
+fromList :: (Hashable k, MapRepr keys vals k v) => [(k, v)] -> HashMap keys vals k v
+{-# INLINE fromList #-}
+fromList = Foldable.foldl' (\m (k, v) -> unsafeInsert k v m) empty
 
-traverseWithKey' :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> HashMap keys as k a -> f (HashMap keys bs k b)
-{-# INLINE traverseWithKey' #-}
-traverseWithKey' !f = \case
-  EmptyMap -> pure EmptyMap
-  (SingletonMap h k v) -> do
-    v' <- f k v
-    pure (SingletonMap h k v')
-  ManyMap sz node -> do
-    node' <- traverseNodeWithKey f node
-    pure (ManyMap sz node')
+-- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
+-- the provided function @f@ to merge duplicate entries with
+-- @(f newVal oldVal)@.
+fromListWith :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
+{-# INLINE fromListWith #-}
+fromListWith f = List.foldl' (\m (k, v) -> unsafeInsertWith f k v m) empty
+
+-- | \(O(n \log32 n)\) Construct a map from a list of elements.  Uses
+-- the provided function @f@ to merge duplicate entries with
+-- @(f key newVal oldVal)@.
+fromListWithKey :: (Eq k, Hashable k, MapRepr keys vals k v) => (k -> v -> v -> v) -> [(k, v)] -> HashMap keys vals k v
+{-# INLINE fromListWithKey #-}
+fromListWithKey f = List.foldl' (\m (k, v) -> unsafeInsertWithKey f k v m) empty
+
+-- | \(O(n)\) Return a list of this map's elements (key-value pairs).
+--
+-- The resulting list is produced lazily and may participate in list fusion.
+-- The order of its elements is unspecified.
+toList :: (MapRepr keys vals k v) => HashMap keys vals k v -> [(k, v)]
+{-# INLINE toList #-}
+toList hashmap = Exts.build (\fusedCons fusedNil -> foldrWithKey (\k v xs -> (k, v) `fusedCons` xs) fusedNil hashmap)
+
+-- | \(O(\log32 n)\) Adjust the value tied to a given key in this map only
+-- if it is present. Otherwise, leave the map alone.
+--
+-- The current implementation is very simple
+-- but is not super performant as it will traverse the map twice.
+adjust :: (Hashable k, MapRepr keys vals k v) => (v -> v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
+adjust f k m = 
+  lookupKVKnownHash# absent present h k m
   where
-    traverseNodeWithKey :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> MapNode keys as k a -> f (MapNode keys bs k b)
-    {-# INLINE traverseNodeWithKey #-}
-    traverseNodeWithKey f = \case
-      CollisionNode keys vals -> do
-        vals' <- traverseInlineKVs f keys vals
-        pure (CollisionNode keys vals')
-      CompactNode bitmap keys vals children -> do
-        vals' <- traverseInlineKVs f keys vals
-        children' <- Contiguous.traverse (traverseNodeWithKey f) children
-        pure (CompactNode bitmap keys vals' children')
-    traverseInlineKVs :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> ArrayOf (Strict keys) k -> ArrayOf as a -> f (ArrayOf bs b)
-    {-# INLINE traverseInlineKVs #-}
-    traverseInlineKVs f keys = Contiguous.itraverse (\i v -> let (# k #) = Contiguous.index# keys i in f k v)
-
--- | Map a function over the values in a hashmap while passing the key to the mapping function.
---
--- O(n)
-mapWithKey :: (MapRepr keys vals k a, MapRepr keys vals k b) => (k -> a -> b) -> HashMap keys vals k a -> HashMap keys vals k b
-{-# INLINE mapWithKey #-}
-mapWithKey = mapWithKey'
-
--- | Map a function over the values in a hashmap while passing the key to the mapping function,
--- and allowing to switch the value storage type.
---
--- that is: you can switch between HashMapBL <-> HashMapBB <-> HashMapBU,
--- or switch between HashMapUL <-> HashMapUB <-> HashMapUU.
---
--- When using this function, you will need 
--- to specify the type of the output map.
---
--- O(n)
-mapWithKey' :: (MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> b) -> HashMap keys as k a -> HashMap keys bs k b
-{-# INLINE mapWithKey' #-}
-mapWithKey' !f = \case 
-  EmptyMap -> EmptyMap
-  (SingletonMap h k v) -> SingletonMap h k (f k v)
-  (ManyMap sz node) -> ManyMap sz (mapNodeWithKey node)
-    where
-      mapNodeWithKey (CollisionNode keys vals) = (CollisionNode keys (Contiguous.zipWith f keys vals))
-      mapNodeWithKey (CompactNode bitmap keys vals children) =
-        let
-          vals' = Contiguous.zipWith f keys vals
-          children' = Contiguous.map mapNodeWithKey children
-        in
-          CompactNode bitmap keys vals' children'
-
--- | Transform this map by applying a function to every key-value pair
--- and retaining only some of them.
---
--- O(n).
-mapMaybeWithKey :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals k v') => (k -> v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals k v'
-{-# INLINE mapMaybeWithKey #-}
-mapMaybeWithKey = mapMaybeWithKey'
-
--- | \(O(n)\) Transform this map by applying a function to every key-value pair
--- and retaining only some of them.
---
--- Allows changing the value storage type
--- that is: you can switch between HashMapBL <-> HashMapBB <-> HashMapBU,
--- or switch between HashMapUL <-> HashMapUB <-> HashMapUU.
-mapMaybeWithKey' :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals' k v') => (k -> v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals' k v'
-{-# INLINE mapMaybeWithKey' #-}
-mapMaybeWithKey' f = \case
-  EmptyMap -> EmptyMap
-  SingletonMap h k v -> case f k v of
-    Nothing -> EmptyMap
-    Just v' -> SingletonMap h k v'
-  -- eta-expand because of https://gitlab.haskell.org/ghc/ghc/-/issues/23150
-  ManyMap _ node -> Exts.inline $ extractInNode (\k v hint -> mapMaybeKeysVals f k v hint) node
-
-mapMaybeKeysVals
-  :: (MapRepr keys vals k v, MapRepr keys vals' k v')
-  => (k -> v -> Maybe v')
-  -> ArrayOf (Strict keys) k
-  -> ArrayOf vals v
-  -> Int
-  -> (Word32, ArrayOf (Strict keys) k, ArrayOf vals' v')
-{-# INLINE mapMaybeKeysVals #-}
-mapMaybeKeysVals !f !keys !vals !hint =
-  let
-    !(mask, vals') = mapMaybeMask f keys vals hint
-    !keys' = Array.filterUsingMask keys mask hint
-  in (mask, keys', vals')
-
-mapMaybeMask
-  :: ( Contiguous.Contiguous arr1, Element arr1 a
-     , Contiguous.Contiguous arr2, Element arr2 b
-     , Contiguous.ContiguousU arr3, Element arr3 c
-     , Bits bits
-     )
-  => (a -> b -> Maybe c) -> arr1 a -> arr2 b -> Int -> (bits, arr3 c)
-{-# INLINE mapMaybeMask #-}
-mapMaybeMask !f !keys !vals !hint = Contiguous.createT $ do
-  -- Preallocate a larger array
-  dst <- Contiguous.new (Contiguous.size vals + hint)
-  let
-    fillDestination ix (dstIx, mask) a b = case f a b of
-      Nothing -> pure (dstIx, mask)
-      Just c -> do
-        Contiguous.write dst dstIx c
-        pure (dstIx + 1, mask `setBit` ix)
-
-  (finalIx, !mask) <- Contiguous.ifoldlZipWithM' fillDestination (0, zeroBits) keys vals
-  !dst' <- Contiguous.resize dst finalIx
-  pure (mask, dst')
-
--- | \(O(n)\) Transform this map by applying a function to every value
--- and retaining only some of them.
-mapMaybe :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals k v') => (v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals k v'
-{-# INLINE mapMaybe #-}
-mapMaybe f = mapMaybeWithKey' (const f)
-
-mapMaybe' :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals' k v') => (v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals' k v'
-{-# INLINE mapMaybe' #-}
-mapMaybe' f = mapMaybeWithKey' (const f)
-
--- | \(O(n)\) Filter this map by retaining only elements satisfying a
--- predicate.
-filterWithKey :: forall k v keys vals. (Eq k, Hashable k, MapRepr keys vals k v) => (k -> v -> Bool) -> HashMap keys vals k v -> HashMap keys vals k v
-{-# INLINE filterWithKey #-}
-filterWithKey !f = \case
-  EmptyMap -> EmptyMap
-  SingletonMap h k v -> if f k v
-    then SingletonMap h k v
-    else EmptyMap
-  -- eta-expand because of https://gitlab.haskell.org/ghc/ghc/-/issues/23150
-  ManyMap _ node -> Exts.inline $ extractInNode (\k v hint -> filterKeysVals f k v hint) node
-
--- | Generic implementation of filterWithKey and mapMaybeWithKey
-extractInNode
-  :: (MapRepr keys vals k v, MapRepr keys vals' k v', Hashable k)
-  => (ArrayOf (Strict keys) k -> ArrayOf vals v -> Int -> (Word32, ArrayOf (Strict keys) k, ArrayOf vals' v'))
-  -> MapNode keys vals k v
-  -> HashMap keys vals' k v'
-{-# INLINE extractInNode #-}
-extractInNode !extractFrom !node = case node of
-  CollisionNode keys vals ->
-    let (keptKeyIxs :: Word32, keys', vals') = extractFrom keys vals 0
-    in  ManyMap (fromIntegral (popCount keptKeyIxs)) (CollisionNode keys' vals')
-  CompactNode b k v c ->
-    let !result = Exts.inline $ extractCompactNode 0 b k v c
-    in  result
-    where
-      extractCompactNode !shift !bitmap !keys !vals !children =
-        -- Straightforward tactic:
-        -- 1. Run the filter across the inline entries.
-        -- 2. Go over children and run the filter across them.
-        --  a. Remove any child nodes that become empty.
-        --  b. Bring up any child nodes that can be inlined.
-        -- 3. Depending on the final cardinality, emit smaller representations.
-        let
-          -- Go over inline values and see which survive.
-          (booleanMask :: Word32, keys', vals') =
-            extractFrom keys vals (Contiguous.size children)
-          -- Notice that the relative 1 bit positions in the bitmap denote the
-          -- locations of the entries within the arrays. Seeing as we already
-          -- have a boolean bitmask on the entries, we can cross reference it
-          -- with the bitmap and flip entries we removed, without having to
-          -- rehash values.
-          inlineBitmap = bitmap .&. ((1 `unsafeShiftL` 32) - 1)
-          bitmapOnlyInline =
-            maskBitmap booleanMask inlineBitmap
-
-          -- Traverse over children, keeping track of data we need to determine what
-          -- variant of the map node we emit.
-          calcRemovedChild (!childSum, !childMask, !children', !keys', !vals', !dataBitmap) ix (CompactNode b k v c) =
-            let !filteredChild = extractCompactNode (nextShift shift) b k v c
-            in  case filteredChild of
-                  EmptyMap ->
-                    ( childSum
-                    , childMask
-                    , children'
-                    , keys'
-                    , vals'
-                    , dataBitmap
-                    )
-
-                  SingletonMap h k v ->
-                    let
-                      bitpos = maskToBitpos (hashToMask shift h)
-                      !dataBitmap' = dataBitmap .|. bitpos
-                      idx = popCount $ dataBitmap' .&. (bitpos - 1)
-                      !keys'' = Array.insertAt Unsafe keys' idx k
-                      !vals'' = Array.insertAt Unsafe vals' idx v
-                    in
-                      ( childSum
-                      , childMask
-                      , children'
-                      , keys''
-                      , vals''
-                      , dataBitmap'
-                      )
-
-                  ManyMap childCount !child' ->
-                    let
-                      !nrInChildren' = childSum + childCount
-                      !childMask' = childMask `setBit` ix
-                      !idx = popCount $ childMask
-                      -- Notice that the ordering we handle the children in, is
-                      -- the same as what the hashes of the child node present
-                      -- in the bitmap corresponds to. So we can actually always
-                      -- write at the end of the new "filtered" array.
-                      !children'' = Array.replaceAt Unsafe children' idx child'
-                    in
-                      ( nrInChildren'
-                      , childMask'
-                      , children''
-                      , keys'
-                      , vals'
-                      , dataBitmap
-                      )
-          calcRemovedChild _ _ _ = error "impossible"
-
-          (nrInChildren, childMask, children', keys'', vals'', bitmapAllInlined) =
-            Contiguous.ifoldl'
-              calcRemovedChild
-              ( 0
-              , zeroBits
-              , Contiguous.create (Contiguous.new (Contiguous.size children))
-              , keys'
-              , vals'
-              , bitmapOnlyInline
-              )
-              children
-
-          -- Same trick applied to the inline key bitmap.
-          childBitmap = maskBitmap (childMask :: Word32) (bitmap !>>. 32)
-          bitmapRemovedChildren = childBitmap !<<. HASH_CODE_LENGTH
-          children'' = Contiguous.create $ do
-            dst <- Array.unsafeThaw children'
-            Contiguous.resize dst (popCount childMask)
-
-          -- Reduce when appropriate for the cardinality in the node
-          matchOnKeys b k v = \case
-            0 -> EmptyMap
-            1 -> SingletonMap (hash (Contiguous.index k 0)) (Contiguous.index k 0) (Contiguous.index v 0)
-            n -> ManyMap n (CompactNode b k v Contiguous.empty)
-
-          -- Do some optimistic shortcircuiting, to quicken leaves.
-          -- When there're no subnodes, only have to filter inline entries.
-          nrInlineKeys' = fromIntegral $ Contiguous.size keys'
-          nrInlineKeys'' = fromIntegral $ Contiguous.size keys''
-          shortcut c _ | Contiguous.null c =
-            matchOnKeys bitmapOnlyInline keys' vals' nrInlineKeys'
-          -- If all subnodes were filtered out, we only need take into account
-          -- subnodes that were inlined
-          shortcut _ c | Contiguous.null c = matchOnKeys bitmapAllInlined keys'' vals'' nrInlineKeys''
-          shortcut _ !c =
-            ManyMap
-              ( let !total = nrInChildren + nrInlineKeys'' in total )
-              ( let !bitmapComplete = bitmapAllInlined .|. bitmapRemovedChildren
-                in CompactNode
-                  bitmapComplete
-                  keys''
-                  vals''
-                  c
-              )
-        in shortcut children children''
-
--- | It's quite useful to take an existing bitmap, and using a bitmask on
--- the elements, remove bits from the bitmap. To avoid having to rehash values
--- to determine the positions of elements in the bitmap.
-maskBitmap :: (Bits a, Bits b, Bits c, Num a, Num b, Num c) => a -> b -> c
-{-# INLINE maskBitmap #-}
-maskBitmap !booleanMask !bitmap = let !result = go booleanMask bitmap 0 0 in result
-  where
-  go !_ !0 !acc !_ = acc
-  go !0 !_ !acc !_ = acc
-  go !booleanMask !bitmap !acc !ix | bitmap .&. 1 == 0
-    = go booleanMask (bitmap !>>. 1) acc (ix + 1)
-  go !booleanMask !bitmap !acc !ix | booleanMask .&. 1 == 0
-    = go (booleanMask !>>. 1) (bitmap !>>. 1) acc (ix + 1)
-  go !booleanMask !bitmap !acc !ix
-    = go (booleanMask !>>. 1) (bitmap !>>. 1) (acc `setBit` ix) (ix + 1)
-
-boolMask2
-  :: (Contiguous.Contiguous arr1, Element arr1 a, Contiguous.Contiguous arr2, Element arr2 b, Bits bits)
-  => (a -> b -> Bool)
-  -> arr1 a
-  -> arr2 b
-  -> bits
-{-# INLINE boolMask2 #-}
-boolMask2 !f !arr1 !arr2 =
-  let createMask !ix !a !b !acc = if f a b then acc `setBit` ix else acc
-      !mask = Array.ifoldrZipWith' createMask zeroBits arr1 arr2
-  in  mask
-
-filterKeysVals
-  :: (MapRepr keys vals k v, Bits bits, Integral bits)
-  => (k -> v -> Bool)
-  -> ArrayOf (Strict keys) k
-  -> ArrayOf vals v
-  -> Int
-  -> (bits, ArrayOf (Strict keys) k, ArrayOf vals v)
-{-# INLINE filterKeysVals #-}
-filterKeysVals !f !keys !vals !hint =
-  let
-    !mask = boolMask2 f keys vals
-    !keys' = Array.filterUsingMask keys mask hint
-    !vals' = Array.filterUsingMask vals mask hint
-  in (mask, keys', vals')
-
--- | \(O(n)\) Filter this map by retaining only elements satisfying a
--- predicate.
-filter :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> Bool) -> HashMap keys vals k v -> HashMap keys vals k v
-{-# INLINE filter #-}
-filter f = filterWithKey (const f)
-
-instance Foldable (HashMapBL k) where
-  {-# INLINE foldr #-}
-  foldr = Champ.Internal.foldr
-  {-# INLINE foldr' #-}
-  foldr' = Champ.Internal.foldr'
-  {-# INLINE foldl #-}
-  foldl = Champ.Internal.foldl
-  {-# INLINE foldl' #-}
-  foldl' = Champ.Internal.foldl'
-  {-# INLINE null #-}
-  null = Champ.Internal.null
-  {-# INLINE length #-}
-  length = Champ.Internal.size
-
-instance Foldable (HashMapBB k) where
-  {-# INLINE foldr #-}
-  foldr = Champ.Internal.foldr
-  {-# INLINE foldr' #-}
-  foldr' = Champ.Internal.foldr'
-  {-# INLINE foldl #-}
-  foldl = Champ.Internal.foldl
-  {-# INLINE foldl' #-}
-  foldl' = Champ.Internal.foldl'
-  {-# INLINE null #-}
-  null = Champ.Internal.null
-  {-# INLINE length #-}
-  length = Champ.Internal.size
-
-instance (Prim k) => Foldable (HashMapUL k) where
-  {-# INLINE foldr #-}
-  foldr = Champ.Internal.foldr
-  {-# INLINE foldr' #-}
-  foldr' = Champ.Internal.foldr'
-  {-# INLINE foldl #-}
-  foldl = Champ.Internal.foldl
-  {-# INLINE foldl' #-}
-  foldl' = Champ.Internal.foldl'
-  {-# INLINE null #-}
-  null = Champ.Internal.null
-  {-# INLINE length #-}
-  length = Champ.Internal.size
-
-instance (Prim k) => Foldable (HashMapUB k) where
-  {-# INLINE foldr #-}
-  foldr = Champ.Internal.foldr
-  {-# INLINE foldr' #-}
-  foldr' = Champ.Internal.foldr'
-  {-# INLINE foldl #-}
-  foldl = Champ.Internal.foldl
-  {-# INLINE foldl' #-}
-  foldl' = Champ.Internal.foldl'
-  {-# INLINE null #-}
-  null = Champ.Internal.null
-  {-# INLINE length #-}
-  length = Champ.Internal.size
+    h = hash k
+    absent (# #) = m
+    present k' v = 
+      let v' = f v 
+      in insert' Safe h k' v' m 
 
 
 {-# INLINE foldr #-}
-foldr :: (MapRepr keys vals k v) => (v -> r -> r) -> r -> HashMap keys vals k v -> r
-foldr f z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, _k, v #) | #) -> f v z0
-  (# | | (# _size, node0 #) #) -> Exts.inline go node0 z0
+foldr :: forall keys vals k v r. (MapRepr keys vals k v) => (v -> r -> r) -> r -> HashMap keys vals k v -> r
+foldr f z0 m = case m of
+  EmptyMap -> z0
+  (SingletonMap _h _k v) -> f v z0
+  (ManyMap _size node0) -> Exts.inline go node0 z0
   where
-    go (MapNode _bitmap _keys !vals !children) z =
+    go (MapNode _bitmap _keys (unBox @(ArrayOf vals v) -> !vals) !children) z =
       z
         & flip (Contiguous.foldr f) vals
         & flip (Contiguous.foldr go) children
 
 {-# INLINE foldl #-}
-foldl :: (MapRepr keys vals k v) => (r -> v -> r) -> r -> HashMap keys vals k v -> r
-foldl f z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, _k, v #) | #) -> f z0 v
-  (# | | (# _size, node0 #) #) -> Exts.inline go z0 node0
+foldl :: forall keys vals k v r. (MapRepr keys vals k v) => (r -> v -> r) -> r -> HashMap keys vals k v -> r
+foldl f z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h _k v -> f z0 v
+  ManyMap _size node0 -> Exts.inline go z0 node0
   where
-    go z (MapNode _bitmap _keys !vals !children) =
+    go z (MapNode _bitmap _keys (unBox @(ArrayOf vals v) -> !vals) !children) =
       z
         & flip (Contiguous.foldl go) children
         & flip (Contiguous.foldl f) vals
 
 
 {-# INLINE foldr' #-}
-foldr' :: (MapRepr keys vals k v) => (v -> r -> r) -> r -> HashMap keys vals k v -> r
-foldr' f !z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, _k, v #) | #) -> f v z0
-  (# | | (# _size, node0 #) #) -> Exts.inline go node0 z0
+foldr' :: forall keys vals k v r. (MapRepr keys vals k v) => (v -> r -> r) -> r -> HashMap keys vals k v -> r
+foldr' f !z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h _k v -> f v z0
+  ManyMap _size node0 -> Exts.inline go node0 z0
   where
-    go (MapNode _bitmap _keys !vals !children) !z =
+    go (MapNode _bitmap _keys (unBox @(ArrayOf vals v) -> !vals) !children) !z =
       z
         & flip (Contiguous.foldr' f) vals
         & flip (Contiguous.foldr' go) children
 
 {-# INLINE foldl' #-}
-foldl' :: (MapRepr keys vals k v) => (r -> v -> r) -> r -> HashMap keys vals k v -> r
-foldl' f !z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, _k, v #) | #) -> f z0 v
-  (# | | (# _size, node0 #) #) -> Exts.inline go z0 node0
+foldl' :: forall keys vals k v r. (MapRepr keys vals k v) => (r -> v -> r) -> r -> HashMap keys vals k v -> r
+foldl' f !z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h _k v -> f z0 v
+  ManyMap _size node0 -> Exts.inline go z0 node0
   where
-    go !z (MapNode _bitmap _keys !vals !children) =
+    go !z (MapNode _bitmap _keys (unBox @(ArrayOf vals v) -> !vals) !children) =
       z
         & flip (Contiguous.foldl' go) children
         & flip (Contiguous.foldl' f) vals
 
 {-# INLINE foldrWithKey #-}
-foldrWithKey :: (MapRepr keys vals k v) => (k -> v -> r -> r) -> r -> HashMap keys vals k v -> r
-foldrWithKey f z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, k, v #) | #) -> f k v z0
-  (# | | (# _size, node0 #) #) -> Exts.inline go node0 z0
+foldrWithKey :: forall keys vals k v r. (MapRepr keys vals k v) => (k -> v -> r -> r) -> r -> HashMap keys vals k v -> r
+foldrWithKey f z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h k v -> f k v z0
+  ManyMap _size node0 -> Exts.inline go node0 z0
   where
-    go (MapNode _bitmap keys !vals !children) z =
+    go (MapNode _bitmap (unBox @(ArrayOf (Strict keys) k) -> !keys) (unBox @(ArrayOf vals v) -> !vals) !children) z =
       z
         & (\acc -> (Contiguous.foldrZipWith f) acc keys vals)
         & flip (Contiguous.foldr go) children
 
 
 {-# INLINE foldrWithKey' #-}
-foldrWithKey' :: (MapRepr keys vals k v) => (k -> v -> r -> r) -> r -> HashMap keys vals k v -> r
-foldrWithKey' f !z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, k, v #) | #) -> f k v z0
-  (# | | (# _size, node0 #) #) -> Exts.inline go node0 z0
+foldrWithKey' :: forall keys vals k v r. (MapRepr keys vals k v) => (k -> v -> r -> r) -> r -> HashMap keys vals k v -> r
+foldrWithKey' f !z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h k v -> f k v z0
+  ManyMap _size node0 -> Exts.inline go node0 z0
   where
-    go (MapNode _bitmap !keys !vals !children) !z =
+    go (MapNode _bitmap (unBox @(ArrayOf (Strict keys) k) -> !keys) (unBox @(ArrayOf vals v) -> !vals) !children) !z =
       z
         & (\acc -> (Array.foldrZipWith' f) acc keys vals)
         & flip (Contiguous.foldr' go) children
 
 {-# INLINE foldlWithKey #-}
-foldlWithKey :: (MapRepr keys vals k v) => (r -> k -> v -> r) -> r -> HashMap keys vals k v -> r
-foldlWithKey f z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, k, v #) | #) -> f z0 k v
-  (# | | (# _size, node0 #) #) -> Exts.inline go z0 node0
+foldlWithKey :: forall keys vals k v r. (MapRepr keys vals k v) => (r -> k -> v -> r) -> r -> HashMap keys vals k v -> r
+foldlWithKey f z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h k v -> f z0 k v
+  ManyMap _size node0 -> Exts.inline go z0 node0
   where
-    go !z (MapNode _bitmap keys !vals !children) =
+    go !z (MapNode _bitmap (unBox @(ArrayOf (Strict keys) k) -> !keys) (unBox @(ArrayOf vals v) -> !vals) !children) =
       z
         & flip (Contiguous.foldl go) children
         & (\acc -> (Array.foldlZipWith f) acc keys vals)
 
 {-# INLINE foldlWithKey' #-}
-foldlWithKey' :: (MapRepr keys vals k v) => (r -> k -> v -> r) -> r -> HashMap keys vals k v -> r
-foldlWithKey' f !z0 m = case matchMap m of
-  (# (# #) | | #) -> z0
-  (# | (# _h, k, v #) | #) -> f z0 k v
-  (# | | (# _size, node0 #) #) -> Exts.inline go z0 node0
+foldlWithKey' :: forall keys vals k v r. (MapRepr keys vals k v) => (r -> k -> v -> r) -> r -> HashMap keys vals k v -> r
+foldlWithKey' f !z0 m = case m of
+  EmptyMap -> z0
+  SingletonMap _h k v -> f z0 k v
+  ManyMap _size node0 -> Exts.inline go z0 node0
   where
-    go !z (MapNode _bitmap keys !vals !children) =
+    go !z (MapNode _bitmap (unBox @(ArrayOf (Strict keys) k) -> !keys) (unBox @(ArrayOf vals v) -> !vals) !children) =
       z
         & (\acc -> (Contiguous.foldlZipWith' f) acc keys vals)
         & flip (Contiguous.foldl' go) children
@@ -1572,13 +1068,13 @@ foldlWithKey' f !z0 m = case matchMap m of
 -- and combining the results with a monoid operation.
 --
 -- Iteration order is unspecified
-foldMapWithKey :: (MapRepr keys vals k v, Monoid m) => (k -> v -> m) -> HashMap keys vals k v -> m
-foldMapWithKey f m = case matchMap m of
-  (# (# #) | | #) -> mempty
-  (# | (# _h, k, v #) | #) -> f k v
-  (# | | (# _size, node0 #) #) -> Exts.inline go node0
+foldMapWithKey :: forall keys vals k v m. (MapRepr keys vals k v, Monoid m) => (k -> v -> m) -> HashMap keys vals k v -> m
+foldMapWithKey f m = case m of
+  EmptyMap -> mempty
+  SingletonMap _h k v -> f k v
+  ManyMap _size node0 -> Exts.inline go node0
   where
-    go (MapNode _bitmap keys vals !children) = 
+    go (MapNode _bitmap (unBox @(ArrayOf (Strict keys) k) -> !keys) (unBox @(ArrayOf vals v) -> !vals) !children) = 
       (Contiguous.foldrZipWith (\k v acc -> acc <> (f k v) )) mempty keys vals
       <> Contiguous.foldMap go children
 {-# INLINE foldMapWithKey #-}
@@ -1612,28 +1108,36 @@ instance (Show k, Show v, MapRepr keys vals k v) => Show (HashMap keys vals k v)
 --
 convert :: forall h1 h2 {ks} {ks'} {vs} {vs'} {k} {v}. (h1 ~ HashMap ks vs, h2 ~ HashMap ks' vs', MapRepr ks vs k v, MapRepr ks' vs' k v) => HashMap ks vs k v -> HashMap ks' vs' k v
 {-# INLINE [2] convert #-}
-convert m = case matchMap m of
-  (# (# #) | | #) -> EmptyMap
-  (# | (# h, k, v #) | #) -> SingletonMap h k v
-  (# | | (# size, node #) #) -> ManyMap size (convert' node)
+convert m = case m of
+  EmptyMap -> EmptyMap
+  SingletonMap h k v -> SingletonMap h k v
+  ManyMap size node -> ManyMap size (convert' node)
   where
     convert' :: MapNode ks vs k v -> MapNode ks' vs' k v
-    convert' (MapNode bitmap keys vals children) = (MapNode bitmap (Contiguous.convert keys) (Contiguous.convert vals) (Contiguous.map convert' children))
-
--- {-# RULES 
--- "Champ.HashMap.convert to the identical type" forall (h :: HashMap ks vs k v). convert @(HashMap ks vs) @(HashMap ks vs) h = h
---   #-}
-
+    convert' (MapNode bitmap (unBox @(ArrayOf (Strict ks) k) -> !keys) (unBox @(ArrayOf vs v) -> !vals) !children) = 
+        let 
+            keys' = Contiguous.convert @(ArrayOf (Strict ks)) @k @(ArrayOf (Strict ks')) keys
+            vals' = Contiguous.convert @(ArrayOf vs) @v @(ArrayOf vs') vals
+            children' = Contiguous.map convert' children
+            in
+                MapNode bitmap (toBox keys') (toBox vals') children'
 
 convertDropVals :: forall h1 h2 {ks} {ks'} {vs} {k} {v}. (h1 ~ HashMap ks vs, h2 ~ HashMap ks' Unexistent, MapRepr ks vs k v, MapRepr ks' Unexistent k ()) => HashMap ks vs k v -> HashMap ks' Unexistent k ()
 {-# INLINE [2] convertDropVals #-}
-convertDropVals m = case matchMap m of
-  (# (# #) | | #) -> EmptyMap
-  (# | (# h, k, _v #) | #) -> SingletonMap h k ()
-  (# | | (# size, node #) #) -> ManyMap size (convert' node)
+convertDropVals m = case m of
+  EmptyMap -> EmptyMap
+  SingletonMap h k _v -> SingletonMap h k ()
+  ManyMap size node -> ManyMap size (convert' node)
   where
     convert' :: MapNode ks vs k v -> MapNode ks' Unexistent k ()
-    convert' (MapNode bitmap keys vals children) = (MapNode bitmap (Contiguous.convert keys) (Contiguous.replicate (Contiguous.size vals) ()) (Contiguous.map convert' children))
+    convert' (MapNode bitmap (unBox @(ArrayOf (Strict ks) k)-> !keys) (unBox @(ArrayOf vs v) -> !vals) children) =
+        let 
+            keys' = Contiguous.convert @(ArrayOf (Strict ks)) @k @(ArrayOf (Strict ks')) keys
+            vals' :: ArrayOf Unexistent ()
+            vals' = Contiguous.replicate (Contiguous.size vals) ()
+            children' = Contiguous.map convert' children
+            in
+                MapNode bitmap (toBox keys') (toBox vals') children'
 
 -- | Print the internal representation of the hashmap.
 --
@@ -1816,96 +1320,462 @@ compose bc !ab
   | null bc = empty
   | otherwise = mapMaybe' (\b -> lookup b bc) ab
 
--- Inside a MapNode,
--- the lower 32 bits indicate the inline leaves
--- and the higher 32 bits indicate child nodes
-newtype Bitmap = Bitmap Word64
-  deriving (Eq, Ord, Num, Bits, Enum, Real, Integral, FiniteBits, NFData)
+instance Traversable (HashMapBL k) where
+  traverse = Champ.Internal.traverse
 
-instance Show Bitmap where
-  -- \| Shows a bitmap in binary, with the lowest bit on the left
-  -- and always padded to 32 bits
-  show :: Bitmap -> String
-  show bitmap = "( " <> show32 bitmap <> ", " <> show32 (bitmap `unsafeShiftR` HASH_CODE_LENGTH) <> ")"
+instance Traversable (HashMapBB k) where
+  traverse = Champ.Internal.traverse
+
+traverse :: (Applicative f, MapRepr keys vals k a, MapRepr keys vals k b) => (a -> f b) -> HashMap keys vals k a -> f (HashMap keys vals k b)
+{-# INLINE traverse #-}
+traverse f = traverseWithKey (const f)
+
+traverse' :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (a -> f b) -> HashMap keys as k a -> f (HashMap keys bs k b)
+{-# INLINE traverse' #-}
+traverse' f = traverseWithKey' (const f)
+
+traverseWithKey :: (Applicative f, MapRepr keys vals k a, MapRepr keys vals k b) => (k -> a -> f b) -> HashMap keys vals k a -> f (HashMap keys vals k b)
+{-# INLINE traverseWithKey #-}
+traverseWithKey = traverseWithKey'
+
+traverseWithKey' :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> HashMap keys as k a -> f (HashMap keys bs k b)
+{-# INLINE traverseWithKey' #-}
+traverseWithKey' !f = \case
+  EmptyMap -> pure EmptyMap
+  (SingletonMap h k v) -> do
+    v' <- f k v
+    pure (SingletonMap h k v')
+  ManyMap sz node -> do
+    node' <- traverseNodeWithKey f node
+    pure (ManyMap sz node')
+  where
+    traverseNodeWithKey :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> MapNode keys as k a -> f (MapNode keys bs k b)
+    {-# INLINE traverseNodeWithKey #-}
+    traverseNodeWithKey f = \case
+      CollisionNode keys vals -> do
+        vals' <- traverseInlineKVs f keys vals
+        pure (CollisionNode keys vals')
+      CompactNode bitmap keys vals children -> do
+        vals' <- traverseInlineKVs f keys vals
+        children' <- Contiguous.traverse (traverseNodeWithKey f) children
+        pure (CompactNode bitmap keys vals' children')
+    traverseInlineKVs :: (Applicative f, MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> f b) -> ArrayOf (Strict keys) k -> ArrayOf as a -> f (ArrayOf bs b)
+    {-# INLINE traverseInlineKVs #-}
+    traverseInlineKVs f keys = Contiguous.itraverse (\i v -> let (# k #) = Contiguous.index# keys i in f k v)
+
+-- | Map a function over the values in a hashmap while passing the key to the mapping function.
+--
+-- O(n)
+mapWithKey :: (MapRepr keys vals k a, MapRepr keys vals k b) => (k -> a -> b) -> HashMap keys vals k a -> HashMap keys vals k b
+{-# INLINE mapWithKey #-}
+mapWithKey = mapWithKey'
+
+-- | Map a function over the values in a hashmap while passing the key to the mapping function,
+-- and allowing to switch the value storage type.
+--
+-- that is: you can switch between HashMapBL <-> HashMapBB <-> HashMapBU,
+-- or switch between HashMapUL <-> HashMapUB <-> HashMapUU.
+--
+-- When using this function, you will need 
+-- to specify the type of the output map.
+--
+-- O(n)
+mapWithKey' :: (MapRepr keys as k a, MapRepr keys bs k b) => (k -> a -> b) -> HashMap keys as k a -> HashMap keys bs k b
+{-# INLINE mapWithKey' #-}
+mapWithKey' !f = \case 
+  EmptyMap -> EmptyMap
+  (SingletonMap h k v) -> SingletonMap h k (f k v)
+  (ManyMap sz node) -> ManyMap sz (mapNodeWithKey node)
     where
-      show32 b = take 32 $ reverse (showBin b "") <> repeat '0'
+      mapNodeWithKey (CollisionNode keys vals) = (CollisionNode keys (Contiguous.zipWith f keys vals))
+      mapNodeWithKey (CompactNode bitmap keys vals children) =
+        let
+          vals' = Contiguous.zipWith f keys vals
+          children' = Contiguous.map mapNodeWithKey children
+        in
+          CompactNode bitmap keys vals' children'
 
-newtype Mask = Mask Word
-  deriving (Eq, Ord, Show)
-
-newtype Hash = Hash Word64
-  deriving (Eq, Ord, Show)
-
-hash :: (Hashable a) => a -> Hash
-hash x = Hash $ fromIntegral $ Hashable.hash x
-
-{-# INLINE hashToMask #-}
-hashToMask :: Word -> Hash -> Mask
-hashToMask (fromIntegral -> depth) (Hash keyhash) = Mask $ (fromIntegral $ keyhash `unsafeShiftR` depth) .&. BIT_PARTITION_MASK
-
-{-# INLINE maskToBitpos #-}
-maskToBitpos :: Mask -> Bitmap
-maskToBitpos (Mask mask) = 1 `unsafeShiftL` (fromIntegral mask)
-
-{-# INLINE childrenBitmap #-}
-childrenBitmap :: (MapRepr keys vals k v) => MapNode keys vals k v -> Bitmap
-childrenBitmap (MapNode bitmap _ _ _) = bitmap `unsafeShiftR` 32
-
-{-# INLINE leavesBitmap #-}
-leavesBitmap :: (MapRepr keys vals k v) => MapNode keys vals k v -> Bitmap
-leavesBitmap (MapNode bitmap _ _ _) = bitmap .&. (1 `unsafeShiftL` 32 - 1)
-
-{-# INLINE leavesCount #-}
-leavesCount :: (Element (ArrayOf (Strict keys)) k) => (MapRepr keys vals k v) => MapNode keys vals k v -> Int
-leavesCount (CollisionNode keys _) = Contiguous.size keys `div` 2 -- The count of leaves in a CollisionNode
-leavesCount node = popCount $ leavesBitmap node
-
-{-# INLINE childrenCount #-}
-childrenCount :: (MapRepr keys vals k v) => MapNode keys vals k v -> Int
-childrenCount node = popCount $ childrenBitmap node
-
--- | Given a Bitpos, returns the index into the elems array of a node (looking at how many other elems are already in the node's databitmap)
-dataIndex :: (MapRepr keys vals k v) => MapNode keys vals k v -> Bitmap -> Int
-{-# INLINE dataIndex #-}
-dataIndex (MapNode bitmap _ _ _) bitpos =
-  popCount $ bitmap .&. (bitpos - 1)
-
--- | Given a Bitpos, returns the index into the elems array of a node (looking at how many other elems are already in the node's nodebitmap)
-childrenIndex :: (MapRepr keys vals k v) => MapNode keys vals k v -> Bitmap -> Int
-{-# INLINE childrenIndex #-}
-childrenIndex node bitpos =
-  popCount $ (childrenBitmap node) .&. (bitpos - 1)
-
-nextShift :: (Num a) => a -> a
-nextShift s = s + BIT_PARTITION_SIZE
-
--- intsToList :: HashMapBL Int Int -> [(Int, Int)]
--- intsToList = Champ.Internal.toList
-
--- sumStrict :: HashMapBB Int Int -> Int
--- sumStrict = foldr' (+) 0
-
--- sumLazy :: HashMapBL Int Int -> Int
--- sumLazy = foldr' (+) 0
-
--- | `Data.Coerce.coerce` but specialized to `Champ.HashMap`
--- See `Champ.HashMap.coercion` for more information.
-coerce :: forall v v' keys vals k. (Coercible v v', MapRepr keys vals k v, MapRepr keys vals k v') => HashMap keys vals k v -> HashMap keys vals k v'
-coerce = Data.Type.Coercion.coerceWith (coercion (Coercion @v @v'))
-
--- | Constructs a `Data.Type.Coercion.Coercion` to safely coerce between two `Champ.HashMap`s
+-- | Transform this map by applying a function to every key-value pair
+-- and retaining only some of them.
 --
--- It is safe to coerce between two HashMaps when:
+-- O(n).
+mapMaybeWithKey :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals k v') => (k -> v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals k v'
+{-# INLINE mapMaybeWithKey #-}
+mapMaybeWithKey = mapMaybeWithKey'
+
+-- | \(O(n)\) Transform this map by applying a function to every key-value pair
+-- and retaining only some of them.
 --
--- - Their value type is coercible
--- - Their key type remains the same
--- - Their key storage and value storage remains the same
+-- Allows changing the value storage type
+-- that is: you can switch between HashMapBL <-> HashMapBB <-> HashMapBU,
+-- or switch between HashMapUL <-> HashMapUB <-> HashMapUU.
+mapMaybeWithKey' :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals' k v') => (k -> v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals' k v'
+{-# INLINE mapMaybeWithKey' #-}
+mapMaybeWithKey' f = \case
+  EmptyMap -> EmptyMap
+  SingletonMap h k v -> case f k v of
+    Nothing -> EmptyMap
+    Just v' -> SingletonMap h k v'
+  -- eta-expand because of https://gitlab.haskell.org/ghc/ghc/-/issues/23150
+  ManyMap _ node -> Exts.inline $ extractInNode (\k v hint -> mapMaybeKeysVals f k v hint) node
+
+mapMaybeKeysVals
+  :: (MapRepr keys vals k v, MapRepr keys vals' k v')
+  => (k -> v -> Maybe v')
+  -> ArrayOf (Strict keys) k
+  -> ArrayOf vals v
+  -> Int
+  -> (Word32, ArrayOf (Strict keys) k, ArrayOf vals' v')
+{-# INLINE mapMaybeKeysVals #-}
+mapMaybeKeysVals !f !keys !vals !hint =
+  let
+    !(mask, vals') = mapMaybeMask f keys vals hint
+    !keys' = Array.filterUsingMask keys mask hint
+  in (mask, keys', vals')
+
+mapMaybeMask
+  :: ( Contiguous.Contiguous arr1, Element arr1 a
+     , Contiguous.Contiguous arr2, Element arr2 b
+     , Contiguous.ContiguousU arr3, Element arr3 c
+     , Bits bits
+     )
+  => (a -> b -> Maybe c) -> arr1 a -> arr2 b -> Int -> (bits, arr3 c)
+{-# INLINE mapMaybeMask #-}
+mapMaybeMask !f !keys !vals !hint = Contiguous.createT $ do
+  -- Preallocate a larger array
+  dst <- Contiguous.new (Contiguous.size vals + hint)
+  let
+    fillDestination ix (dstIx, mask) a b = case f a b of
+      Nothing -> pure (dstIx, mask)
+      Just c -> do
+        Contiguous.write dst dstIx c
+        pure (dstIx + 1, mask `setBit` ix)
+
+  (finalIx, !mask) <- Contiguous.ifoldlZipWithM' fillDestination (0, zeroBits) keys vals
+  !dst' <- Contiguous.resize dst finalIx
+  pure (mask, dst')
+
+-- | \(O(n)\) Transform this map by applying a function to every value
+-- and retaining only some of them.
+mapMaybe :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals k v') => (v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals k v'
+{-# INLINE mapMaybe #-}
+mapMaybe f = mapMaybeWithKey' (const f)
+
+mapMaybe' :: (Eq k, Hashable k, MapRepr keys vals k v, MapRepr keys vals' k v') => (v -> Maybe v') -> HashMap keys vals k v -> HashMap keys vals' k v'
+{-# INLINE mapMaybe' #-}
+mapMaybe' f = mapMaybeWithKey' (const f)
+
+
+-- | Generic implementation of filterWithKey and mapMaybeWithKey
+extractInNode
+  :: (MapRepr keys vals k v, MapRepr keys vals' k v', Hashable k)
+  => (ArrayOf (Strict keys) k -> ArrayOf vals v -> Int -> (Word32, ArrayOf (Strict keys) k, ArrayOf vals' v'))
+  -> MapNode keys vals k v
+  -> HashMap keys vals' k v'
+{-# INLINE extractInNode #-}
+extractInNode !extractFrom !node = case node of
+  CollisionNode keys vals ->
+    let (keptKeyIxs :: Word32, keys', vals') = extractFrom keys vals 0
+    in  ManyMap (fromIntegral (popCount keptKeyIxs)) (CollisionNode keys' vals')
+  CompactNode b k v c ->
+    let !result = Exts.inline $ extractCompactNode 0 b k v c
+    in  result
+    where
+      extractCompactNode !shift !bitmap !keys !vals !children =
+        -- Straightforward tactic:
+        -- 1. Run the filter across the inline entries.
+        -- 2. Go over children and run the filter across them.
+        --  a. Remove any child nodes that become empty.
+        --  b. Bring up any child nodes that can be inlined.
+        -- 3. Depending on the final cardinality, emit smaller representations.
+        let
+          -- Go over inline values and see which survive.
+          (booleanMask :: Word32, keys', vals') =
+            extractFrom keys vals (Contiguous.size children)
+          -- Notice that the relative 1 bit positions in the bitmap denote the
+          -- locations of the entries within the arrays. Seeing as we already
+          -- have a boolean bitmask on the entries, we can cross reference it
+          -- with the bitmap and flip entries we removed, without having to
+          -- rehash values.
+          inlineBitmap = bitmap .&. ((1 `unsafeShiftL` 32) - 1)
+          bitmapOnlyInline =
+            maskBitmap booleanMask inlineBitmap
+
+          -- Traverse over children, keeping track of data we need to determine what
+          -- variant of the map node we emit.
+          calcRemovedChild (!childSum, !childMask, !children', !keys', !vals', !dataBitmap) ix (CompactNode b k v c) =
+            let !filteredChild = extractCompactNode (nextShift shift) b k v c
+            in  case filteredChild of
+                  EmptyMap ->
+                    ( childSum
+                    , childMask
+                    , children'
+                    , keys'
+                    , vals'
+                    , dataBitmap
+                    )
+
+                  SingletonMap h k v ->
+                    let
+                      bitpos = maskToBitpos (hashToMask shift h)
+                      !dataBitmap' = dataBitmap .|. bitpos
+                      idx = popCount $ dataBitmap' .&. (bitpos - 1)
+                      !keys'' = Array.insertAt Unsafe keys' idx k
+                      !vals'' = Array.insertAt Unsafe vals' idx v
+                    in
+                      ( childSum
+                      , childMask
+                      , children'
+                      , keys''
+                      , vals''
+                      , dataBitmap'
+                      )
+
+                  ManyMap childCount !child' ->
+                    let
+                      !nrInChildren' = childSum + childCount
+                      !childMask' = childMask `setBit` ix
+                      !idx = popCount $ childMask
+                      -- Notice that the ordering we handle the children in, is
+                      -- the same as what the hashes of the child node present
+                      -- in the bitmap corresponds to. So we can actually always
+                      -- write at the end of the new "filtered" array.
+                      !children'' = Array.replaceAt Unsafe children' idx child'
+                    in
+                      ( nrInChildren'
+                      , childMask'
+                      , children''
+                      , keys'
+                      , vals'
+                      , dataBitmap
+                      )
+          calcRemovedChild _ _ _ = error "impossible"
+
+          (nrInChildren, childMask, children', keys'', vals'', bitmapAllInlined) =
+            Contiguous.ifoldl'
+              calcRemovedChild
+              ( 0
+              , zeroBits
+              , Contiguous.create (Contiguous.new (Contiguous.size children))
+              , keys'
+              , vals'
+              , bitmapOnlyInline
+              )
+              children
+
+          -- Same trick applied to the inline key bitmap.
+          childBitmap = maskBitmap (childMask :: Word32) (bitmap !>>. 32)
+          bitmapRemovedChildren = childBitmap !<<. HASH_CODE_LENGTH
+          children'' = Contiguous.create $ do
+            dst <- Array.unsafeThaw children'
+            Contiguous.resize dst (popCount childMask)
+
+          -- Reduce when appropriate for the cardinality in the node
+          matchOnKeys b k v = \case
+            0 -> EmptyMap
+            1 -> SingletonMap (hash (Contiguous.index k 0)) (Contiguous.index k 0) (Contiguous.index v 0)
+            n -> ManyMap n (CompactNode b k v Contiguous.empty)
+
+          -- Do some optimistic shortcircuiting, to quicken leaves.
+          -- When there're no subnodes, only have to filter inline entries.
+          nrInlineKeys' = fromIntegral $ Contiguous.size keys'
+          nrInlineKeys'' = fromIntegral $ Contiguous.size keys''
+          shortcut c _ | Contiguous.null c =
+            matchOnKeys bitmapOnlyInline keys' vals' nrInlineKeys'
+          -- If all subnodes were filtered out, we only need take into account
+          -- subnodes that were inlined
+          shortcut _ c | Contiguous.null c = matchOnKeys bitmapAllInlined keys'' vals'' nrInlineKeys''
+          shortcut _ !c =
+            ManyMap
+              ( let !total = nrInChildren + nrInlineKeys'' in total )
+              ( let !bitmapComplete = bitmapAllInlined .|. bitmapRemovedChildren
+                in CompactNode
+                  bitmapComplete
+                  keys''
+                  vals''
+                  c
+              )
+        in shortcut children children''
+
+
+-- | It's quite useful to take an existing bitmap, and using a bitmask on
+-- the elements, remove bits from the bitmap. To avoid having to rehash values
+-- to determine the positions of elements in the bitmap.
+maskBitmap :: (Bits a, Bits b, Bits c, Num a, Num b, Num c) => a -> b -> c
+{-# INLINE maskBitmap #-}
+maskBitmap !booleanMask !bitmap = let !result = go booleanMask bitmap 0 0 in result
+  where
+  go !_ !0 !acc !_ = acc
+  go !0 !_ !acc !_ = acc
+  go !booleanMask !bitmap !acc !ix | bitmap .&. 1 == 0
+    = go booleanMask (bitmap !>>. 1) acc (ix + 1)
+  go !booleanMask !bitmap !acc !ix | booleanMask .&. 1 == 0
+    = go (booleanMask !>>. 1) (bitmap !>>. 1) acc (ix + 1)
+  go !booleanMask !bitmap !acc !ix
+    = go (booleanMask !>>. 1) (bitmap !>>. 1) (acc `setBit` ix) (ix + 1)
+
+boolMask2
+  :: (Contiguous.Contiguous arr1, Element arr1 a, Contiguous.Contiguous arr2, Element arr2 b, Bits bits)
+  => (a -> b -> Bool)
+  -> arr1 a
+  -> arr2 b
+  -> bits
+{-# INLINE boolMask2 #-}
+boolMask2 !f !arr1 !arr2 =
+  let createMask !ix !a !b !acc = if f a b then acc `setBit` ix else acc
+      !mask = Array.ifoldrZipWith' createMask zeroBits arr1 arr2
+  in  mask
+
+
+instance Foldable (HashMapBL k) where
+  {-# INLINE foldr #-}
+  foldr = Champ.Internal.foldr
+  {-# INLINE foldr' #-}
+  foldr' = Champ.Internal.foldr'
+  {-# INLINE foldl #-}
+  foldl = Champ.Internal.foldl
+  {-# INLINE foldl' #-}
+  foldl' = Champ.Internal.foldl'
+  {-# INLINE null #-}
+  null = Champ.Internal.null
+  {-# INLINE length #-}
+  length = Champ.Internal.size
+
+instance Foldable (HashMapBB k) where
+  {-# INLINE foldr #-}
+  foldr = Champ.Internal.foldr
+  {-# INLINE foldr' #-}
+  foldr' = Champ.Internal.foldr'
+  {-# INLINE foldl #-}
+  foldl = Champ.Internal.foldl
+  {-# INLINE foldl' #-}
+  foldl' = Champ.Internal.foldl'
+  {-# INLINE null #-}
+  null = Champ.Internal.null
+  {-# INLINE length #-}
+  length = Champ.Internal.size
+
+instance (Prim k) => Foldable (HashMapUL k) where
+  {-# INLINE foldr #-}
+  foldr = Champ.Internal.foldr
+  {-# INLINE foldr' #-}
+  foldr' = Champ.Internal.foldr'
+  {-# INLINE foldl #-}
+  foldl = Champ.Internal.foldl
+  {-# INLINE foldl' #-}
+  foldl' = Champ.Internal.foldl'
+  {-# INLINE null #-}
+  null = Champ.Internal.null
+  {-# INLINE length #-}
+  length = Champ.Internal.size
+
+instance (Prim k) => Foldable (HashMapUB k) where
+  {-# INLINE foldr #-}
+  foldr = Champ.Internal.foldr
+  {-# INLINE foldr' #-}
+  foldr' = Champ.Internal.foldr'
+  {-# INLINE foldl #-}
+  foldl = Champ.Internal.foldl
+  {-# INLINE foldl' #-}
+  foldl' = Champ.Internal.foldl'
+  {-# INLINE null #-}
+  null = Champ.Internal.null
+  {-# INLINE length #-}
+  length = Champ.Internal.size
+
+
+-- | \(O(\log32 n)\)  The expression @('alter' f k map)@ alters the value @x@ at @k@, or
+-- absence thereof.
 --
--- However, because of the way Champ.HashMap is implemented using associated data families,
--- we cannot directly use 'type role annotations' that would give rise to the appropriate `Coercible` constraint.
--- /(the role annotation of the value type inside Champ.HashMap is `nominal` rather than `representational`.)/
+-- 'alter' can be used to insert, delete, or update a value in a map.
 --
--- Instead, we use explicit t`Data.Type.Coercion.Coercion`s.
-coercion :: forall h1 h2 {keys} {vals} {k} {v} {v'}. (h1 ~ HashMap keys vals k v, h2 ~ HashMap keys vals k v', MapRepr keys vals k v, MapRepr keys vals k v') => Coercion v v' -> Coercion h1 h2
-coercion c@Coercion = unsafeCoerce c
-  
+-- If the function returns Nothing, the key is removed from the map.
+-- If the function returns Just v', the key is inserted or replaced with the new value.
+--
+-- The current implementation is very simple,
+-- but is not super performant.
+alter :: (Hashable k, MapRepr keys vals k v) => (Maybe v -> Maybe v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
+{-# INLINABLE alter #-}
+alter f k m = 
+  let h = hash k
+  in
+  case lookupKVKnownHash h k m of
+  Nothing -> 
+    case f Nothing of
+      Nothing -> m
+      Just v -> insert' Safe h k v m
+  Just (k', v) -> 
+    case f (Just v) of
+      Nothing -> delete' Safe h k' m
+      Just v' -> if ptrEq v v' then m else insert' Safe h k' v' m
+
+-- | \(O(\log32 n)\)  The expression @('update' f k map)@ updates the value @x@ at @k@
+-- (if it is in the map). If @(f x)@ is 'Nothing', the element is deleted.
+-- If it is @('Just' y)@, the key @k@ is bound to the new value @y@.
+update :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> Maybe v) -> k -> HashMap keys vals k v -> HashMap keys vals k v
+{-# INLINABLE update #-}
+update f = alter (>>= f)
+
+-- | \(O(\log32 n)\)  The expression @('alterF' f k map)@ alters the value @x@ at
+-- @k@, or absence thereof.
+--
+--  'alterF' can be used to insert, delete, or update a value in a map.
+--
+-- 'alterF' is a flipped version of the 'at' combinator from
+-- <https://hackage.haskell.org/package/lens/docs/Control-Lens-At.html#v:at Control.Lens.At>.
+--
+--
+-- The current implementation does not (yet) have a set of rewrite rules in place
+-- that optimize particular common kinds of `f`. 
+alterF :: (MapRepr keys vals a1 a2, Hashable a1, Functor f) => (Maybe a2 -> f (Maybe a2)) -> a1 -> HashMap keys vals a1 a2 -> f (HashMap keys vals a1 a2)
+{-# INLINE alterF #-}
+alterF f = \ !k !m ->
+  let
+    !h = hash k
+  in
+    case lookupKVKnownHash h k m of
+      Nothing -> do
+        mv <- (f Nothing)
+        pure $ case mv of
+          Nothing -> m
+          Just v -> (insert' Safe h k v m)
+      Just (k', v) -> do 
+        mv <- (f (Just v))
+        pure $ case mv of
+          Nothing -> delete' Safe h k' m
+          Just v' -> insert' Safe h k' v' m
+
+
+-- | \(O(n)\) Filter this map by retaining only elements satisfying a
+-- predicate.
+filterWithKey :: forall k v keys vals. (Eq k, Hashable k, MapRepr keys vals k v) => (k -> v -> Bool) -> HashMap keys vals k v -> HashMap keys vals k v
+{-# INLINE filterWithKey #-}
+filterWithKey !f = \case
+  EmptyMap -> EmptyMap
+  SingletonMap h k v -> if f k v
+    then SingletonMap h k v
+    else EmptyMap
+  -- eta-expand because of https://gitlab.haskell.org/ghc/ghc/-/issues/23150
+  ManyMap _ node -> Exts.inline $ extractInNode (\k v hint -> filterKeysVals f k v hint) node
+
+
+filterKeysVals
+  :: (MapRepr keys vals k v, Bits bits, Integral bits)
+  => (k -> v -> Bool)
+  -> ArrayOf (Strict keys) k
+  -> ArrayOf vals v
+  -> Int
+  -> (bits, ArrayOf (Strict keys) k, ArrayOf vals v)
+{-# INLINE filterKeysVals #-}
+filterKeysVals !f !keys !vals !hint =
+  let
+    !mask = boolMask2 f keys vals
+    !keys' = Array.filterUsingMask keys mask hint
+    !vals' = Array.filterUsingMask vals mask hint
+  in (mask, keys', vals')
+
+-- | \(O(n)\) Filter this map by retaining only elements satisfying a
+-- predicate.
+filter :: (Eq k, Hashable k, MapRepr keys vals k v) => (v -> Bool) -> HashMap keys vals k v -> HashMap keys vals k v
+{-# INLINE filter #-}
+filter f = filterWithKey (const f)

--- a/champ-core/src/Champ/Internal.hs
+++ b/champ-core/src/Champ/Internal.hs
@@ -583,7 +583,7 @@ lookupKV# !k = lookupKVKnownHash# absent present (hash k) k
     present k' v = (# | (# k', v #) #)
 
 lookupKVKnownHash :: (MapRepr keys vals a b, Hashable a) => Hash -> a -> HashMap keys vals a b -> Maybe (a, b)
-{-# INLINE lookupKVKnownHash #-}
+--{-# INLINE lookupKVKnownHash #-}
 lookupKVKnownHash = lookupKVKnownHash# absent present
   where
     absent (# #) = Nothing
@@ -604,7 +604,7 @@ lookupKVKnownHash# absent present h !k m = case m of
             k' = unBox singleKey
             v' = unSolo @vals (unBox singleVal)
         in
-            if h == h' && k == k' then present k v' else absent (# #)
+            if h == h' && k == k' then present k' v' else absent (# #)
   HashMap _ (MapNode bitmap (unBox @(ArrayOf (Strict keys) k) -> keys) (unBox @(ArrayOf vals v) -> vals) children) ->
 --   EmptyMap -> absent (# #)
 --   SingletonMap h' k' v' -> if h == h' && k == k' then present k' v' else absent (# #)

--- a/champ/src/Champ/HashMap.hs
+++ b/champ/src/Champ/HashMap.hs
@@ -87,9 +87,9 @@ module Champ.HashMap (
     -- ** Between map types
     Champ.Internal.convert,
 
-    -- *** Coercions
-    Champ.Internal.coerce,
-    Champ.Internal.coercion,
+    -- -- *** Coercions
+    -- Champ.Internal.coerce,
+    -- Champ.Internal.coercion,
 
     -- ** Lists
     Champ.Internal.fromList,

--- a/champ/src/Champ/HashSet.hs
+++ b/champ/src/Champ/HashSet.hs
@@ -107,6 +107,10 @@ type role HashSet nominal nominal
 
 type SetRepr elems e = Champ.Internal.MapRepr elems Unexistent e ()
 
+-- class SetRepr elems e where
+
+-- instance (Champ.Internal.MapRepr elems Unexistent e ()) => SetRepr elems e where
+
 -- | A HashSet with strict boxed elements
 --
 -- This is a drop-in replacement for `Data.HashSet`
@@ -141,25 +145,25 @@ instance (Eq e, SetRepr elems e) => Eq (HashSet elems e) where
 
 insert :: (Hashable e, SetRepr elems e) => e -> HashSet elems e -> HashSet elems e
 {-# INLINE insert #-}
-insert e = coerce Champ.Internal.insert e ()
+insert e (HashSet h) = HashSet $ Champ.Internal.insert e () h
 
 fromList :: (Hashable e, SetRepr elems e) => [e] -> HashSet elems e
 {-# INLINE fromList #-}
-fromList = coerce Champ.Internal.fromList . fmap (\x -> (x, ()))
+fromList = HashSet . Champ.Internal.fromList . fmap (\x -> (x, ()))
 
 toList :: (SetRepr elems e) => HashSet elems e -> [e]
 {-# INLINE toList #-}
-toList = Champ.Internal.keys . coerce
+toList (HashSet h) = Champ.Internal.keys h
 
 -- | \O(1)\ Construct the empty set
 empty :: (SetRepr elems e) => HashSet elems e
 {-# INLINE empty #-}
-empty = coerce Champ.Internal.empty
+empty = HashSet Champ.Internal.empty
 
 -- | \O(1)\ Return `True` if the set is empty, `False` otherwise
 null :: (SetRepr elems e) => HashSet elems e -> Bool
 {-# INLINE null #-}
-null = coerce Champ.Internal.null
+null (HashSet h) = Champ.Internal.null h
 
 
 -- | \O(1)\ Return the number of elements in this set.
@@ -168,17 +172,17 @@ null = coerce Champ.Internal.null
 -- this function runs in constant-time.
 size :: (SetRepr elems e) => HashSet elems e -> Int
 {-# INLINE size #-}
-size = coerce Champ.Internal.size
+size (HashSet h) = Champ.Internal.size h
 
 -- | \O(1)\ Construct a one-element set
 singleton :: (Hashable e, SetRepr elems e) => e -> HashSet elems e
 {-# INLINE singleton #-}
-singleton e = coerce Champ.Internal.singleton e ()
+singleton e = HashSet $ Champ.Internal.singleton e ()
 
 -- | \O(log n)\ Return `True` if the specified element is present in the set, `False` otherwise.
 member :: (SetRepr elems e, Hashable e) => e -> HashSet elems e -> Bool
 {-# INLINE member #-}
-member = coerce Champ.Internal.member
+member e (HashSet h) = Champ.Internal.member e h
 
 -- | Look up whether a given element `e` exists in the set.
 --
@@ -187,7 +191,7 @@ member = coerce Champ.Internal.member
 -- with an element that is _identical_ (pointer-equality).
 lookup :: (SetRepr elems e, Hashable e) => e -> HashSet elems e -> Maybe e
 {-# INLINE lookup #-}
-lookup e set = fst <$> Champ.Internal.lookupKV e (coerce set)
+lookup e (HashSet h) = fst <$> Champ.Internal.lookupKV e h
 
 -- | \(O(n)\) Transform this set by applying a function to every value.
 -- The resulting set may be smaller than the source.
@@ -249,7 +253,7 @@ foldMap f set = Champ.Internal.foldMapWithKey (\e () -> f e) (coerce set)
 -- performing repeated insertion
 union :: (Hashable e, SetRepr elems e) => HashSet elems e -> HashSet elems e -> HashSet elems e
 {-# INLINE union #-}
-union = coerce Champ.Internal.union
+union (HashSet h1) (HashSet h2) = HashSet $ Champ.Internal.union h1 h2
 
 -- | The union of a list (or other foldable) of sets.
 --
@@ -259,11 +263,11 @@ union = coerce Champ.Internal.union
 -- performing repeated insertion
 unions :: (Foldable f, Hashable e, SetRepr elems e) => f (HashSet elems e) -> HashSet elems e
 {-# INLINE unions #-}
-unions = coerce . Champ.Internal.unions . fmap coerce . Data.Foldable.toList
+unions sets = HashSet $ Champ.Internal.unions $ fmap coerce $ Data.Foldable.toList sets
 
 delete :: (Hashable e, SetRepr elems e) => e -> HashSet elems e -> HashSet elems e
 {-# INLINE delete #-}
-delete = coerce Champ.Internal.delete
+delete e (HashSet h) = HashSet $ Champ.Internal.delete e h
 
 -- | \(O(n \log m)\) Difference of two sets. Return elements of the first set
 -- not existing in the second.
@@ -272,7 +276,7 @@ delete = coerce Champ.Internal.delete
 -- as we fold one set over the other instead of walking over the two sets in lock-step.
 difference :: (Hashable e, SetRepr elems e) => HashSet elems e -> HashSet elems e -> HashSet elems e
 {-# INLINE difference #-}
-difference = coerce Champ.Internal.difference
+difference (HashSet h1) (HashSet h2) = HashSet $ Champ.Internal.difference h1 h2
 
 -- | \(O(n \log m)\) Intersection of two sets. Return elements of the first set
 -- also existing in the second.
@@ -281,7 +285,7 @@ difference = coerce Champ.Internal.difference
 -- as we fold one map over the other instead of walking over the two maps in lock-step.
 intersection :: (Hashable e, SetRepr elems e) => HashSet elems e -> HashSet elems e -> HashSet elems e
 {-# INLINE intersection #-}
-intersection = coerce Champ.Internal.intersection
+intersection (HashSet h1) (HashSet h2) = HashSet $ Champ.Internal.intersection h1 h2
 
 -- | Set inclusion.
 --
@@ -289,7 +293,7 @@ intersection = coerce Champ.Internal.intersection
 -- as we fold one set over the other instead of walking over the two sets in lock-step.
 isSubsetOf :: (Hashable e, SetRepr elems e) => HashSet elems e -> HashSet elems e -> Bool
 {-# INLINE isSubsetOf #-}
-isSubsetOf = coerce Champ.Internal.isSubmapOf
+isSubsetOf (HashSet h1) (HashSet h2) = Champ.Internal.isSubmapOf h1 h2
 
 -- TODO: Implement the other foldXWithKey's as well,
 -- so we can wrap them here
@@ -311,7 +315,7 @@ instance Foldable (HashSet Boxed) where
     length = Champ.HashSet.size
 
 convert :: forall s1 s2 {es} {es'} {e}. (s1 ~ HashSet es, s2 ~ HashSet es', SetRepr es e, SetRepr es' e) => HashSet es e -> HashSet es' e
-convert = coerce Champ.Internal.convert
+convert (HashSet h) = HashSet (Champ.Internal.convert h)
 
 
 -- | \(O(1)\) Convert to set to the equivalent 'HashMap' with @()@ values.


### PR DESCRIPTION
Triggers a GHC Internal Compiler Error related to `findSlot`

```
	findSlot
  Can't find slot
  sum_slots:[PtrLiftedSlot, PtrLiftedSlot]
  arg_slots:[PtrUnliftedSlot, PtrLiftedSlot]
```

This seems to be related on how `lookupKVKnownHash#` is implemented, but it only is triggered when it is applied a particular `present` and `absent` continuation.

Also note that NOINLINE-ing `unBox` resolves the problem.
Also, changing the line `present k' v'` to return the _other_ key (that the user passed in) ([here](https://github.com/Qqwy/haskell-champ/pull/29/changes/85bda13aa9646bf013c9d70d0783ab38a3d5414b#diff-0bf6df1b679434903aec1cba1ac949fc71e36edf243f6505ca65b406dfcfbcaeR607)), resolves the problem because then we do not take the key.